### PR TITLE
Add support for CF kit v1

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -56,6 +56,9 @@ for want in $GENESIS_REQUESTED_FEATURES; do
         manifests+=( "upstream/operations/cf-mysql-db.yml" )
       fi
       ;;
+    cf-v1-support)
+      manifests+=( "overlay/cf-v1-support.yml" )
+      ;;
     *)
       __bail "$GENESIS_KIT_ID does not support the #c{$want} feature"
       ;;

--- a/overlay/cf-v1-support.yml
+++ b/overlay/cf-v1-support.yml
@@ -1,0 +1,26 @@
+# Use historic instance group name instead of log-api from
+# canonical cf-deployment
+addons:
+- name: bosh-dns-aliases
+  jobs:
+  - name: bosh-dns-aliases
+    properties:
+      aliases:
+      - (( merge on domain ))
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - (( merge on query ))
+        - query: "*"
+          instance_group: loggregator_trafficcontroller
+
+bosh-variables:
+  cf_client_id: (( param "Please specify the CF client ID" ))
+  cf_client_secret: (( param "Please specify the CF client secret" ))
+  loggregator_ca:
+    certificate: (( param "Please specify the Loggregrator CA" ))
+  loggregator_tls_agent:
+    certificate: (( param "Please specify the Loggregrator TLS Certificate" ))
+    private_key: (( param "Please specify the Loggregrator TLS Private Key" ))
+  loggregator_tls_rlp:
+    certificate: (( param "Please specify the Loggregrator TLS RLP Certificate" ))
+    private_key: (( param "Please specify the Loggregrator TLS RLP Private Key" ))


### PR DESCRIPTION
CF kit v1 uses a non-canonical `instance_group` name for `log-api`. This causes RLP lookups to fail in the `asnozzle` to fail. This corrects this problem. CF kit v1 also doesn't support the exodus data required by this kit so it will prompt you for the necessary information.