### PR TITLE
Bionic Support and bug fixes

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,10 @@
-# Bug Fix
+# Features
 
-* Fix mixup when extracting exodus data for Cloud Foundry loggregator TLS agent and RLP certs.
+* Using upstream 4.0.0
+* Added bionic support on all instances
 
-* Fixes issue where deploy would fail due to kit not using Bosh DNS runtime config.
+# Bug Fixes
+
+* Fixes issue where pull upstream would fail to retrieve the corresponding release
+* Fixes issue where the overlay would ignore the deployment and network provided for nats under bosh-dns-aliases addons and the deployment for route registrar job under specific instance groups
+

--- a/devtools/pull-upstream
+++ b/devtools/pull-upstream
@@ -26,7 +26,7 @@ file="$workdir/${package}-${version}.tar.gz"
 echo "Fetching ${package} v${version} release from ${github_org} Github organization}"
 
 curl -sSL -o "$file"\
-  "https://github.com/${github_org}/${package}/archive/v${version}.tar.gz" > /dev/null
+  "https://github.com/${github_org}/${package}/archive/refs/tags/${version}.tar.gz" > /dev/null
 if ! [[ -f "$file" ]] ; then
   error "Failed to download ${package} v${version} -- cannot continue"
 fi

--- a/overlay/change_deployment_and_network.yml
+++ b/overlay/change_deployment_and_network.yml
@@ -69,6 +69,20 @@ addons:
           deployment: (( grab name ))
           network:    (( grab params.network ))
 
+      - domain: nats.service.cf.internal
+        targets:
+        - (( merge on query ))
+        - query: '*'
+          deployment: (( grab meta.cf.deployment_name ))
+          network:    (( grab params.cf_core_network ))
+
+      - domain: _.nats.service.cf.internal
+        targets:
+        - (( merge on query ))
+        - query: '_'
+          deployment: (( grab meta.cf.deployment_name ))
+          network:    (( grab params.cf_core_network ))
+
 instance_groups:
 - name: postgres_autoscaler
   networks:
@@ -79,16 +93,31 @@ instance_groups:
   networks:
   - (( replace ))
   - name: (( grab params.network ))
+  jobs:
+  - name: route_registrar
+    consumes:
+      nats: 
+        deployment: (( grab meta.cf.deployment_name ))
 
 - name: asmetrics
   networks:
   - (( replace ))
   - name: (( grab params.network ))
+  jobs:
+  - name: route_registrar
+    consumes:
+      nats: 
+        deployment: (( grab meta.cf.deployment_name ))
 
 - name: asnozzle
   networks:
   - (( replace ))
   - name: (( grab params.network ))
+  jobs:
+  - name: route_registrar
+    consumes:
+      nats: 
+        deployment: (( grab meta.cf.deployment_name ))
 
 - name: asapi
   networks:

--- a/overlay/upstream_version.yml
+++ b/overlay/upstream_version.yml
@@ -1,3 +1,3 @@
 exodus:
-  app-autoscaler-release-version: 3.0.1
-  app-autoscaler-release-date:    2020-Jun-15 22:05:34 UTC
+  app-autoscaler-release-version: 4.0.0
+  app-autoscaler-release-date:    2022-Jan-11 09:55:37 UTC

--- a/spec/credhub/base.yml
+++ b/spec/credhub/base.yml
@@ -96,3 +96,10 @@ servicebroker_server:
   ca: <!{credhub}:servicebroker_server.ca!>
   certificate: <!{credhub}:servicebroker_server.certificate!>
   private_key: <!{credhub}:servicebroker_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
+autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>

--- a/spec/credhub/cf-v1-support.yml
+++ b/spec/credhub/cf-v1-support.yml
@@ -96,3 +96,10 @@ servicebroker_server:
   ca: <!{credhub}:servicebroker_server.ca!>
   certificate: <!{credhub}:servicebroker_server.certificate!>
   private_key: <!{credhub}:servicebroker_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
+autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>

--- a/spec/credhub/external-db.yml
+++ b/spec/credhub/external-db.yml
@@ -95,3 +95,10 @@ servicebroker_server:
   ca: <!{credhub}:servicebroker_server.ca!>
   certificate: <!{credhub}:servicebroker_server.certificate!>
   private_key: <!{credhub}:servicebroker_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
+autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>

--- a/spec/credhub/mysql.yml
+++ b/spec/credhub/mysql.yml
@@ -96,3 +96,10 @@ servicebroker_server:
   ca: <!{credhub}:servicebroker_server.ca!>
   certificate: <!{credhub}:servicebroker_server.certificate!>
   private_key: <!{credhub}:servicebroker_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
+autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>

--- a/spec/credhub/params.yml
+++ b/spec/credhub/params.yml
@@ -95,3 +95,10 @@ servicebroker_server:
   ca: <!{credhub}:servicebroker_server.ca!>
   certificate: <!{credhub}:servicebroker_server.certificate!>
   private_key: <!{credhub}:servicebroker_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
+autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -1,8 +1,5 @@
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
-  jobs:
+- jobs:
   - name: bosh-dns-aliases
     properties:
       aliases:
@@ -69,11 +66,29 @@ addons:
           instance_group: asmetrics
           network: test-core-network
           query: '*'
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: _
     release: bosh-dns-aliases
   name: bosh-dns-aliases
+- jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
 exodus:
-  app-autoscaler-release-date: 2020-Jun-15 22:05:34 UTC
-  app-autoscaler-release-version: 3.0.1
+  app-autoscaler-release-date: 2022-Jan-11 09:55:37 UTC
+  app-autoscaler-release-version: 4.0.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: base
@@ -162,7 +177,9 @@ instance_groups:
           ca_cert: <!{credhub}:scalingengine_ca.ca!>
           defaultCoolDownSecs: 300
           health:
+            password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
+            username: scalingengine
           http_client_timeout: 60s
           lockSize: 32
           logging:
@@ -243,7 +260,10 @@ instance_groups:
         scheduler:
           ca_cert: <!{credhub}:scheduler_ca.ca!>
           health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
             port: 6202
+            username: scheduler
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -359,7 +379,9 @@ instance_groups:
             retry_interval: 5s
             ttl: 15s
           health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
             port: 6208
+            username: operator
           http_client_timeout: 60s
           logging:
             level: info
@@ -420,6 +442,36 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scalingengine_health
+          port: 6204
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scalingengine_health
+          uris:
+          - autoscaler-scalingengine.sys.test.cf.domain
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - autoscaler-operator.sys.test.cf.domain
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - autoscaler-scheduler.sys.test.cf.domain
+    release: routing
   name: asactors
   networks:
   - name: test-core-network
@@ -472,7 +524,9 @@ instance_groups:
             refresh_interval: 60s
             save_interval: 5s
           health:
+            password: <!{credhub}:autoscaler_metricsserver_health_password!>
             port: 6303
+            username: metricsserver
           http_client_timeout: 60s
           logging:
             level: info
@@ -550,7 +604,9 @@ instance_groups:
             evaluator_count: 20
             trigger_array_channel_size: 200
           health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
             port: 6205
+            username: eventgenerator
           http_client_timeout: 60s
           logging:
             level: info
@@ -594,6 +650,29 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - autoscaler-eventgenerator.sys.test.cf.domain
+        - name: autoscaler_metricsserver_health
+          port: 6303
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsserver_health
+          uris:
+          - autoscaler-metricsserver.sys.test.cf.domain
+    release: routing
   name: asmetrics
   networks:
   - name: test-core-network
@@ -625,7 +704,9 @@ instance_groups:
             retry_delay: 1s
           envelop_chan_size: 1000
           health:
+            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
             port: 6503
+            username: metricsgateway
           logging:
             level: info
           nozzle:
@@ -660,6 +741,22 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_metricsgateway_health
+          port: 6503
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsgateway_health
+          uris:
+          - autoscaler-metricsgateway.sys.test.cf.domain
+    release: routing
   name: asnozzle
   networks:
   - name: test-core-network
@@ -780,7 +877,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           cache_ttl: 900s
           health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
             port: 6403
+            username: metricsforwarder
           logging:
             level: info
           loggregator:
@@ -846,9 +945,14 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metricsforwarder_health
+          port: 6403
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - name: bpm
-    release: bpm
   - consumes:
       doppler:
         deployment: base-test-cf
@@ -877,27 +981,30 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1
   version: 3.0.1
 - name: postgres
-  sha1: 20929ee4b0c64fd97072a266311a6d00714124a7
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25
-  version: "25"
+  sha1: 24d2e2887a45258b71bc40577c0f406180e47701
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29
+  version: "29"
 - name: bosh-dns-aliases
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3
 - name: routing
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  version: 0.162.0
+  sha1: edb2f822ca5bbe579a179abfa4b053dc9c99224f
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0
+  version: 0.223.0
 - name: loggregator-agent
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
 - name: bpm
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 update:

--- a/spec/results/cf-v1-support.yml
+++ b/spec/results/cf-v1-support.yml
@@ -1,8 +1,5 @@
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
-  jobs:
+- jobs:
   - name: bosh-dns-aliases
     properties:
       aliases:
@@ -69,11 +66,29 @@ addons:
           instance_group: asmetrics
           network: test-core-network
           query: '*'
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: _
     release: bosh-dns-aliases
   name: bosh-dns-aliases
+- jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
 exodus:
-  app-autoscaler-release-date: 2020-Jun-15 22:05:34 UTC
-  app-autoscaler-release-version: 3.0.1
+  app-autoscaler-release-date: 2022-Jan-11 09:55:37 UTC
+  app-autoscaler-release-version: 4.0.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: cf-v1-support
@@ -162,7 +177,9 @@ instance_groups:
           ca_cert: <!{credhub}:scalingengine_ca.ca!>
           defaultCoolDownSecs: 300
           health:
+            password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
+            username: scalingengine
           http_client_timeout: 60s
           lockSize: 32
           logging:
@@ -243,7 +260,10 @@ instance_groups:
         scheduler:
           ca_cert: <!{credhub}:scheduler_ca.ca!>
           health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
             port: 6202
+            username: scheduler
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -359,7 +379,9 @@ instance_groups:
             retry_interval: 5s
             ttl: 15s
           health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
             port: 6208
+            username: operator
           http_client_timeout: 60s
           logging:
             level: info
@@ -420,6 +442,36 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scalingengine_health
+          port: 6204
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scalingengine_health
+          uris:
+          - autoscaler-scalingengine.sys.test.cf.domain
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - autoscaler-operator.sys.test.cf.domain
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - autoscaler-scheduler.sys.test.cf.domain
+    release: routing
   name: asactors
   networks:
   - name: test-core-network
@@ -472,7 +524,9 @@ instance_groups:
             refresh_interval: 60s
             save_interval: 5s
           health:
+            password: <!{credhub}:autoscaler_metricsserver_health_password!>
             port: 6303
+            username: metricsserver
           http_client_timeout: 60s
           logging:
             level: info
@@ -550,7 +604,9 @@ instance_groups:
             evaluator_count: 20
             trigger_array_channel_size: 200
           health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
             port: 6205
+            username: eventgenerator
           http_client_timeout: 60s
           logging:
             level: info
@@ -594,6 +650,29 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - autoscaler-eventgenerator.sys.test.cf.domain
+        - name: autoscaler_metricsserver_health
+          port: 6303
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsserver_health
+          uris:
+          - autoscaler-metricsserver.sys.test.cf.domain
+    release: routing
   name: asmetrics
   networks:
   - name: test-core-network
@@ -625,7 +704,9 @@ instance_groups:
             retry_delay: 1s
           envelop_chan_size: 1000
           health:
+            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
             port: 6503
+            username: metricsgateway
           logging:
             level: info
           nozzle:
@@ -660,6 +741,22 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_metricsgateway_health
+          port: 6503
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsgateway_health
+          uris:
+          - autoscaler-metricsgateway.sys.test.cf.domain
+    release: routing
   name: asnozzle
   networks:
   - name: test-core-network
@@ -780,7 +877,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           cache_ttl: 900s
           health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
             port: 6403
+            username: metricsforwarder
           logging:
             level: info
           loggregator:
@@ -846,9 +945,14 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metricsforwarder_health
+          port: 6403
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - name: bpm
-    release: bpm
   - consumes:
       doppler:
         deployment: base-test-cf
@@ -877,27 +981,30 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1
   version: 3.0.1
 - name: postgres
-  sha1: 20929ee4b0c64fd97072a266311a6d00714124a7
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25
-  version: "25"
+  sha1: 24d2e2887a45258b71bc40577c0f406180e47701
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29
+  version: "29"
 - name: bosh-dns-aliases
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3
 - name: routing
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  version: 0.162.0
+  sha1: edb2f822ca5bbe579a179abfa4b053dc9c99224f
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0
+  version: 0.223.0
 - name: loggregator-agent
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
 - name: bpm
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 update:

--- a/spec/results/external-db.yml
+++ b/spec/results/external-db.yml
@@ -1,8 +1,5 @@
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
-  jobs:
+- jobs:
   - name: bosh-dns-aliases
     properties:
       aliases:
@@ -69,11 +66,29 @@ addons:
           instance_group: asmetrics
           network: test-core-network
           query: '*'
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: _
     release: bosh-dns-aliases
   name: bosh-dns-aliases
+- jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
 exodus:
-  app-autoscaler-release-date: 2020-Jun-15 22:05:34 UTC
-  app-autoscaler-release-version: 3.0.1
+  app-autoscaler-release-date: 2022-Jan-11 09:55:37 UTC
+  app-autoscaler-release-version: 4.0.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: external-db
@@ -123,7 +138,9 @@ instance_groups:
           ca_cert: <!{credhub}:scalingengine_ca.ca!>
           defaultCoolDownSecs: 300
           health:
+            password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
+            username: scalingengine
           http_client_timeout: 60s
           lockSize: 32
           logging:
@@ -189,7 +206,10 @@ instance_groups:
         scheduler:
           ca_cert: <!{credhub}:scheduler_ca.ca!>
           health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
             port: 6202
+            username: scheduler
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -285,7 +305,9 @@ instance_groups:
             retry_interval: 5s
             ttl: 15s
           health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
             port: 6208
+            username: operator
           http_client_timeout: 60s
           logging:
             level: info
@@ -336,6 +358,36 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scalingengine_health
+          port: 6204
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scalingengine_health
+          uris:
+          - autoscaler-scalingengine.sys.test.cf.domain
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - autoscaler-operator.sys.test.cf.domain
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - autoscaler-scheduler.sys.test.cf.domain
+    release: routing
   name: asactors
   networks:
   - name: test-core-network
@@ -383,7 +435,9 @@ instance_groups:
             refresh_interval: 60s
             save_interval: 5s
           health:
+            password: <!{credhub}:autoscaler_metricsserver_health_password!>
             port: 6303
+            username: metricsserver
           http_client_timeout: 60s
           logging:
             level: info
@@ -451,7 +505,9 @@ instance_groups:
             evaluator_count: 20
             trigger_array_channel_size: 200
           health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
             port: 6205
+            username: eventgenerator
           http_client_timeout: 60s
           logging:
             level: info
@@ -490,6 +546,29 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - autoscaler-eventgenerator.sys.test.cf.domain
+        - name: autoscaler_metricsserver_health
+          port: 6303
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsserver_health
+          uris:
+          - autoscaler-metricsserver.sys.test.cf.domain
+    release: routing
   name: asmetrics
   networks:
   - name: test-core-network
@@ -521,7 +600,9 @@ instance_groups:
             retry_delay: 1s
           envelop_chan_size: 1000
           health:
+            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
             port: 6503
+            username: metricsgateway
           logging:
             level: info
           nozzle:
@@ -551,6 +632,22 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_metricsgateway_health
+          port: 6503
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsgateway_health
+          uris:
+          - autoscaler-metricsgateway.sys.test.cf.domain
+    release: routing
   name: asnozzle
   networks:
   - name: test-core-network
@@ -661,7 +758,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           cache_ttl: 900s
           health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
             port: 6403
+            username: metricsforwarder
           logging:
             level: info
           loggregator:
@@ -722,9 +821,14 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metricsforwarder_health
+          port: 6403
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - name: bpm
-    release: bpm
   - consumes:
       doppler:
         deployment: base-test-cf
@@ -753,27 +857,30 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1
   version: 3.0.1
 - name: postgres
-  sha1: 20929ee4b0c64fd97072a266311a6d00714124a7
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25
-  version: "25"
+  sha1: 24d2e2887a45258b71bc40577c0f406180e47701
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29
+  version: "29"
 - name: bosh-dns-aliases
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3
 - name: routing
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  version: 0.162.0
+  sha1: edb2f822ca5bbe579a179abfa4b053dc9c99224f
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0
+  version: 0.223.0
 - name: loggregator-agent
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
 - name: bpm
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 update:

--- a/spec/results/mysql.yml
+++ b/spec/results/mysql.yml
@@ -1,8 +1,5 @@
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
-  jobs:
+- jobs:
   - name: bosh-dns-aliases
     properties:
       aliases:
@@ -69,6 +66,20 @@ addons:
           instance_group: asmetrics
           network: test-core-network
           query: '*'
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: nats
+          network: test-core-network
+          query: _
       - domain: sql-db.service.cf.internal
         targets:
         - deployment: cf
@@ -78,9 +89,13 @@ addons:
           query: '*'
     release: bosh-dns-aliases
   name: bosh-dns-aliases
+- jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
 exodus:
-  app-autoscaler-release-date: 2020-Jun-15 22:05:34 UTC
-  app-autoscaler-release-version: 3.0.1
+  app-autoscaler-release-date: 2022-Jan-11 09:55:37 UTC
+  app-autoscaler-release-version: 4.0.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: mysql
@@ -130,7 +145,9 @@ instance_groups:
           ca_cert: <!{credhub}:scalingengine_ca.ca!>
           defaultCoolDownSecs: 300
           health:
+            password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
+            username: scalingengine
           http_client_timeout: 60s
           lockSize: 32
           logging:
@@ -196,7 +213,10 @@ instance_groups:
         scheduler:
           ca_cert: <!{credhub}:scheduler_ca.ca!>
           health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
             port: 6202
+            username: scheduler
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -292,7 +312,9 @@ instance_groups:
             retry_interval: 5s
             ttl: 15s
           health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
             port: 6208
+            username: operator
           http_client_timeout: 60s
           logging:
             level: info
@@ -343,6 +365,36 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scalingengine_health
+          port: 6204
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scalingengine_health
+          uris:
+          - autoscaler-scalingengine.sys.test.cf.domain
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - autoscaler-operator.sys.test.cf.domain
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - autoscaler-scheduler.sys.test.cf.domain
+    release: routing
   name: asactors
   networks:
   - name: test-core-network
@@ -390,7 +442,9 @@ instance_groups:
             refresh_interval: 60s
             save_interval: 5s
           health:
+            password: <!{credhub}:autoscaler_metricsserver_health_password!>
             port: 6303
+            username: metricsserver
           http_client_timeout: 60s
           logging:
             level: info
@@ -458,7 +512,9 @@ instance_groups:
             evaluator_count: 20
             trigger_array_channel_size: 200
           health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
             port: 6205
+            username: eventgenerator
           http_client_timeout: 60s
           logging:
             level: info
@@ -497,6 +553,29 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - autoscaler-eventgenerator.sys.test.cf.domain
+        - name: autoscaler_metricsserver_health
+          port: 6303
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsserver_health
+          uris:
+          - autoscaler-metricsserver.sys.test.cf.domain
+    release: routing
   name: asmetrics
   networks:
   - name: test-core-network
@@ -528,7 +607,9 @@ instance_groups:
             retry_delay: 1s
           envelop_chan_size: 1000
           health:
+            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
             port: 6503
+            username: metricsgateway
           logging:
             level: info
           nozzle:
@@ -558,6 +639,22 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_metricsgateway_health
+          port: 6503
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsgateway_health
+          uris:
+          - autoscaler-metricsgateway.sys.test.cf.domain
+    release: routing
   name: asnozzle
   networks:
   - name: test-core-network
@@ -668,7 +765,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           cache_ttl: 900s
           health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
             port: 6403
+            username: metricsforwarder
           logging:
             level: info
           loggregator:
@@ -729,9 +828,14 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metricsforwarder_health
+          port: 6403
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - name: bpm
-    release: bpm
   - consumes:
       doppler:
         deployment: base-test-cf
@@ -760,27 +864,30 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1
   version: 3.0.1
 - name: postgres
-  sha1: 20929ee4b0c64fd97072a266311a6d00714124a7
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25
-  version: "25"
+  sha1: 24d2e2887a45258b71bc40577c0f406180e47701
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29
+  version: "29"
 - name: bosh-dns-aliases
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3
 - name: routing
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  version: 0.162.0
+  sha1: edb2f822ca5bbe579a179abfa4b053dc9c99224f
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0
+  version: 0.223.0
 - name: loggregator-agent
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
 - name: bpm
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 update:

--- a/spec/results/params.yml
+++ b/spec/results/params.yml
@@ -1,8 +1,5 @@
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
-  jobs:
+- jobs:
   - name: bosh-dns-aliases
     properties:
       aliases:
@@ -69,11 +66,29 @@ addons:
           instance_group: asmetrics
           network: cf-v1-core-network
           query: '*'
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: base-test-cfv1
+          domain: bosh
+          instance_group: nats
+          network: cf-v1-core-network
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: base-test-cfv1
+          domain: bosh
+          instance_group: nats
+          network: cf-v1-core-network
+          query: _
     release: bosh-dns-aliases
   name: bosh-dns-aliases
+- jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
 exodus:
-  app-autoscaler-release-date: 2020-Jun-15 22:05:34 UTC
-  app-autoscaler-release-version: 3.0.1
+  app-autoscaler-release-date: 2022-Jan-11 09:55:37 UTC
+  app-autoscaler-release-version: 4.0.0
   autoscaler_api_domain: autoscaler.cf-v1.lab.example.com
   autoscaler_metrics_domain: autoscalermetrics.cf-v1.lab.example.com
   bosh: params
@@ -123,7 +138,9 @@ instance_groups:
           ca_cert: <!{credhub}:scalingengine_ca.ca!>
           defaultCoolDownSecs: 300
           health:
+            password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
+            username: scalingengine
           http_client_timeout: 60s
           lockSize: 32
           logging:
@@ -189,7 +206,10 @@ instance_groups:
         scheduler:
           ca_cert: <!{credhub}:scheduler_ca.ca!>
           health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
             port: 6202
+            username: scheduler
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -285,7 +305,9 @@ instance_groups:
             retry_interval: 5s
             ttl: 15s
           health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
             port: 6208
+            username: operator
           http_client_timeout: 60s
           logging:
             level: info
@@ -336,6 +358,36 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scalingengine_health
+          port: 6204
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scalingengine_health
+          uris:
+          - autoscaler-scalingengine.cf-v1.lab.example.com
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - autoscaler-operator.cf-v1.lab.example.com
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - autoscaler-scheduler.cf-v1.lab.example.com
+    release: routing
   name: asactors
   networks:
   - name: cf-v1-core-network
@@ -383,7 +435,9 @@ instance_groups:
             refresh_interval: 60s
             save_interval: 5s
           health:
+            password: <!{credhub}:autoscaler_metricsserver_health_password!>
             port: 6303
+            username: metricsserver
           http_client_timeout: 60s
           logging:
             level: info
@@ -451,7 +505,9 @@ instance_groups:
             evaluator_count: 20
             trigger_array_channel_size: 200
           health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
             port: 6205
+            username: eventgenerator
           http_client_timeout: 60s
           logging:
             level: info
@@ -490,6 +546,29 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - autoscaler-eventgenerator.cf-v1.lab.example.com
+        - name: autoscaler_metricsserver_health
+          port: 6303
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsserver_health
+          uris:
+          - autoscaler-metricsserver.cf-v1.lab.example.com
+    release: routing
   name: asmetrics
   networks:
   - name: cf-v1-core-network
@@ -521,7 +600,9 @@ instance_groups:
             retry_delay: 1s
           envelop_chan_size: 1000
           health:
+            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
             port: 6503
+            username: metricsgateway
           logging:
             level: info
           nozzle:
@@ -551,6 +632,22 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_metricsgateway_health
+          port: 6503
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsgateway_health
+          uris:
+          - autoscaler-metricsgateway.cf-v1.lab.example.com
+    release: routing
   name: asnozzle
   networks:
   - name: cf-v1-core-network
@@ -661,7 +758,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           cache_ttl: 900s
           health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
             port: 6403
+            username: metricsforwarder
           logging:
             level: info
           loggregator:
@@ -722,9 +821,14 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.cf-v1.lab.example.com
+        - name: autoscaler_metricsforwarder_health
+          port: 6403
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - autoscaler-metricsforwarder.cf-v1.lab.example.com
     release: routing
-  - name: bpm
-    release: bpm
   - consumes:
       doppler:
         deployment: base-test-cfv1
@@ -753,27 +857,30 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.1
   version: 3.0.1
 - name: postgres
-  sha1: 20929ee4b0c64fd97072a266311a6d00714124a7
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25
-  version: "25"
+  sha1: 24d2e2887a45258b71bc40577c0f406180e47701
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29
+  version: "29"
 - name: bosh-dns-aliases
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3
 - name: routing
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  version: 0.162.0
+  sha1: edb2f822ca5bbe579a179abfa4b053dc9c99224f
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0
+  version: 0.223.0
 - name: loggregator-agent
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
 - name: bpm
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 update:

--- a/upstream/templates/app-autoscaler-deployment.yml
+++ b/upstream/templates/app-autoscaler-deployment.yml
@@ -7,32 +7,29 @@ releases:
 - name: app-autoscaler
   version: latest
 - name: "postgres"
-  version: "25"
-  url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=25"
-  sha1: "20929ee4b0c64fd97072a266311a6d00714124a7"
+  version: "29"
+  url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=29"
+  sha1: "24d2e2887a45258b71bc40577c0f406180e47701"
 - name: bosh-dns-aliases
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: '0.0.3'
   sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-- name: routing
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.162.0
-  sha1: f17cf09d2414f5f486d18bbd57b17fd48fb69773
-  version: '0.162.0'
+- name: "routing"
+  url: "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.223.0"
+  sha1: "edb2f822ca5bbe579a179abfa4b053dc9c99224f"
+  version: "0.223.0"
 - name: loggregator-agent
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9
   version: "3.9"
   sha1: bf723af956a61c7b51db0ba535c871bad24dd289
 - name: bpm
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
-  version: 1.1.0
-  sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
+  version: 1.1.9
+  sha1: sha256:031cf5600158f44762c747a1f8648b7cebca876d4297dd9e2ce3b51b36ccd476
 features:
   use_dns_addresses: true
 addons:
 - name: bosh-dns-aliases
-  include:
-    stemcell:
-    - os: ubuntu-xenial
   jobs:
   - name: bosh-dns-aliases
     release: bosh-dns-aliases
@@ -101,9 +98,30 @@ addons:
           deployment: app-autoscaler
           network: default
           domain: bosh
+      - domain: nats.service.cf.internal
+        targets:
+          - deployment: cf
+            domain: bosh
+            instance_group: nats
+            network: default
+            query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+          - deployment: cf
+            domain: bosh
+            instance_group: nats
+            network: default
+            query: _
+- name: bpm
+  jobs:
+    - name: bpm
+      release: bpm
 # Stemcell details
 stemcells:
 - alias: default
+  os: ubuntu-bionic
+  version: latest
+- alias: xenial
   os: ubuntu-xenial
   version: latest
 
@@ -187,6 +205,8 @@ instance_groups:
             port: &scalingEnginePort 6104
           health:
             port: &scalingEngineHealthPort 6204
+            username: scalingengine
+            password: ((autoscaler_scalingengine_health_password))
           defaultCoolDownSecs: 300
           lockSize: 32
           ca_cert: ((scalingengine_ca.ca))
@@ -200,6 +220,9 @@ instance_groups:
           port: &schedulerPort 6102
           health:
             port: &schedulerHealthPort 6202
+            basicAuthEnabled: true
+            username: scheduler
+            password: ((autoscaler_scheduler_health_password))
           http_client_timeout: 60
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
@@ -248,6 +271,36 @@ instance_groups:
           http_client_timeout: 60s
           health:
             port: &operatorHealthPort 6208
+            username: operator
+            password: ((autoscaler_operator_health_password))
+  - name: route_registrar
+    release: routing
+    consumes:
+      nats: {from: nats, deployment: cf}
+    properties:
+      route_registrar:
+        routes:
+          - name: autoscaler_scalingengine_health
+            registration_interval: 20s
+            port: *scalingEngineHealthPort
+            tags:
+              component: autoscaler_scalingengine_health
+            uris:
+              - autoscaler-scalingengine.((system_domain))
+          - name: autoscaler_operator_health
+            registration_interval: 20s
+            port: *operatorHealthPort
+            tags:
+              component: autoscaler_operator_health
+            uris:
+              - autoscaler-operator.((system_domain))
+          - name: autoscaler_scheduler_health
+            registration_interval: 20s
+            port: *schedulerHealthPort
+            tags:
+              component: autoscaler_scheduler_health
+            uris:
+              - autoscaler-scheduler.((system_domain))
 # asmetrics Instance Group: metricsserver&eventgenerator
 - name: asmetrics
   azs:
@@ -291,6 +344,8 @@ instance_groups:
             metric_channel_size: 1000
           health:
             port: &metricsserverHealthPort 6303
+            username: metricsserver
+            password: ((autoscaler_metricsserver_health_password))
   - name: eventgenerator
     release: app-autoscaler
     properties:
@@ -307,6 +362,8 @@ instance_groups:
             port: &eventGeneratorPort 6105
           health:
             port: &eventGeneratorHealthPort 6205
+            username: eventgenerator
+            password: ((autoscaler_eventgenerator_health_password))
           ca_cert: ((eventgenerator_ca.ca))
           server_cert: ((eventgenerator_server.certificate))
           server_key: ((eventgenerator_server.private_key))
@@ -339,6 +396,27 @@ instance_groups:
             ca_cert: ((metricsserver_ca.ca))
             client_cert: ((metricsserver_client.certificate))
             client_key: ((metricsserver_client.private_key))
+  - name: route_registrar
+    release: routing
+    consumes:
+      nats: {from: nats, deployment: cf}
+    properties:
+      route_registrar:
+        routes:
+          - name: autoscaler_eventgenerator_health
+            registration_interval: 20s
+            port: *eventGeneratorHealthPort
+            tags:
+              component: autoscaler_eventgenerator_health
+            uris:
+              - autoscaler-eventgenerator.((system_domain))
+          - name: autoscaler_metricsserver_health
+            registration_interval: 20s
+            port: *metricsserverHealthPort
+            tags:
+              component: autoscaler_metricsserver_health
+            uris:
+              - autoscaler-metricsserver.((system_domain))
 - name: asnozzle
   azs:
   - z1
@@ -384,6 +462,22 @@ instance_groups:
               ca_cert: ((loggregator_ca.certificate))
           health:
             port: &metricsgatewayHealthPort 6503
+            username: metricsgateway
+            password: ((autoscaler_metricsgateway_health_password))
+  - name: route_registrar
+    release: routing
+    consumes:
+      nats: {from: nats, deployment: cf}
+    properties:
+      route_registrar:
+        routes:
+          - name: autoscaler_metricsgateway_health
+            registration_interval: 20s
+            port: *metricsgatewayHealthPort
+            tags:
+              component: autoscaler_metricsgateway_health
+            uris:
+              - autoscaler-metricsgateway.((system_domain))
 # asapi Instance Group : apiserver&servicebroker
 - name: asapi
   azs:
@@ -406,7 +500,7 @@ instance_groups:
             level: info
           broker:
             server:
-              port: 6102
+              port: &brokerServerPort 6102
               catalog: 
                 services:
                 - id: autoscaler-guid
@@ -422,7 +516,7 @@ instance_groups:
             password: ((autoscaler_service_broker_password))
           public_api:
             server:
-              port: 6101
+              port: &publicApiServerPort 6101
           use_buildin_mode: false
           scheduler:
             ca_cert: ((scheduler_ca.ca))
@@ -457,7 +551,7 @@ instance_groups:
           logging:
             level: info
           server:
-            port: 6201
+            port: &metricsforwarderServerPort 6201
           loggregator:
             metron_address: "127.0.0.1:3458"
             tls:
@@ -469,7 +563,9 @@ instance_groups:
           cache_cleanup_interval: 6h
           policy_poller_interval: 60s
           health:
-            port: 6403
+            port: &metricsforwarderHealthPort 6403
+            username: metricsforwarder
+            password: ((autoscaler_metricsforwarder_health_password))
         policy_db: *database
         policy_db_connection_config: *databaseConnectionConfig
   - name: route_registrar
@@ -481,27 +577,32 @@ instance_groups:
         routes:
         - name: api_server
           registration_interval: 20s
-          port: 6101
+          port: *publicApiServerPort
           tags:
             component: api_server
           uris:
             - autoscaler.((system_domain))
         - name: autoscaler_service_broker
           registration_interval: 20s
-          port: 6102
+          port: *brokerServerPort
           tags:
             component: autoscaler_service_broker
           uris:
             - autoscalerservicebroker.((system_domain))
         - name: autoscaler_metrics_forwarder
           registration_interval: 20s
-          port: 6201
+          port: *metricsforwarderServerPort
           tags:
             component: autoscaler_metrics_forwarder
           uris:
             - autoscalermetrics.((system_domain))
-  - name: bpm
-    release: bpm
+        - name: autoscaler_metricsforwarder_health
+          registration_interval: 20s
+          port: *metricsforwarderHealthPort
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+            - autoscaler-metricsforwarder.((system_domain))
   - name: loggregator_agent
     release: loggregator-agent
     consumes:
@@ -519,6 +620,20 @@ variables:
   type: password
 - name: autoscaler_service_broker_password
   type: password
+- name: autoscaler_scheduler_health_password
+  type: password
+- name: autoscaler_eventgenerator_health_password
+  type: password
+- name: autoscaler_metricsforwarder_health_password
+  type: password
+- name: autoscaler_metricsgateway_health_password
+  type: password
+- name: autoscaler_metricsserver_health_password
+  type: password
+- name: autoscaler_operator_health_password
+  type: password
+- name: autoscaler_scalingengine_health_password
+  type: password
 - name: scalingengine_ca
   type: certificate
   options:
@@ -529,6 +644,8 @@ variables:
   options:
     ca: scalingengine_ca
     common_name: scalingengine.service.cf.internal
+    alternative_names:
+    - scalingengine.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth
@@ -549,6 +666,8 @@ variables:
   options:
     ca: eventgenerator_ca
     common_name: eventgenerator.service.cf.internal
+    alternative_names:
+    - eventgenerator.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth
@@ -569,6 +688,8 @@ variables:
   options:
     ca: apiserver_ca
     common_name: apiserver.service.cf.internal
+    alternative_names:
+    - apiserver.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth
@@ -582,6 +703,8 @@ variables:
   options:
     ca: apiserver_public_ca
     common_name: autoscaler.((system_domain))
+    alternative_names:
+    - autoscaler.((system_domain))
     extended_key_usage:
     - client_auth
     - server_auth
@@ -602,6 +725,8 @@ variables:
   options:
     ca: servicebroker_ca
     common_name: servicebroker.service.cf.internal
+    alternative_names:
+    - servicebroker.service.cf.internal  
     extended_key_usage:
     - client_auth
     - server_auth
@@ -622,6 +747,8 @@ variables:
   options:
     ca: servicebroker_public_ca
     common_name: autoscalerservicebroker.((system_domain))
+    alternative_names:
+    - autoscalerservicebroker.((system_domain))
     extended_key_usage:
     - client_auth
     - server_auth
@@ -635,6 +762,8 @@ variables:
   options:
     ca: scheduler_ca
     common_name: autoscalerscheduler.service.cf.internal
+    alternative_names:
+    - autoscalerscheduler.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth
@@ -676,6 +805,8 @@ variables:
   options:
     ca: postgres_ca
     common_name: autoscalerpostgres.service.cf.internal
+    alternative_names:
+    - autoscalerpostgres.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth


### PR DESCRIPTION
# Features

* Using upstream 4.0.0
* Added bionic support on all instances

# Bug Fixes

* Fixes issue where pull upstream would fail to retrieve the corresponding release
* Fixes issue where the overlay would ignore the deployment and network provided for nats under bosh-dns-aliases addons and the deployment for route registrar job under specific instance groups

shoutout to @norman-abramovitz and @fearoffish for joining the overlay issue troubleshooting process