### PR TITLE
added 2 year leaf expiration

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -13,6 +13,7 @@ manifests=( \
   "upstream/templates/app-autoscaler-deployment.yml" \
   "overlay/base.yml" \
   "overlay/ten-year-ca-expiry.yml" \
+  "overlay/two-year-leaf-expiry.yml" \
   "overlay/db-persistent-disk.yml" \
   "overlay/upstream_version.yml" \
   "overlay/change_deployment_and_network.yml" \

--- a/overlay/two-year-leaf-expiry.yml
+++ b/overlay/two-year-leaf-expiry.yml
@@ -1,0 +1,19 @@
+# CAs should last 10 years instead of the default Credhub 1y
+variables:
+
+- { name: apiserver_client,               options: { duration: 730 } }
+- { name: apiserver_public_server,        options: { duration: 730 } }
+- { name: apiserver_server,               options: { duration: 730 } }
+- { name: eventgenerator_client,          options: { duration: 730 } }
+- { name: eventgenerator_server,          options: { duration: 730 } }
+- { name: metricsserver_client,           options: { duration: 730 } }
+- { name: metricsserver_server,           options: { duration: 730 } }
+- { name: postgres_server,                options: { duration: 730 } }
+- { name: scalingengine_client,           options: { duration: 730 } }
+- { name: scalingengine_server,           options: { duration: 730 } }
+- { name: scheduler_client,               options: { duration: 730 } }
+- { name: scheduler_server,               options: { duration: 730 } }
+- { name: servicebroker_client,           options: { duration: 730 } }
+- { name: servicebroker_public_server,    options: { duration: 730 } }
+- { name: servicebroker_server,           options: { duration: 730 } }
+


### PR DESCRIPTION
Given the fact that each certificate rotation happens slightly earlier than a full year, subsequent rotations may collide with other critical scheduled jobs or otherwise intensive calendar days (vacation, fiscal year ending, promotions etc).
The proposed changes allow for each leaf certificate to last for two years which allows the operator to schedule the leaf certificate rotation on a yearly basis without having to make any changes based on the impending certificate expiry. 