### PR TITLE
adding override to upstream to fix broker uri

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -35,6 +35,7 @@ do
         "ocfp/ocfp.yml"
         "ocfp/loggregator-agent.yml"
         "ocfp/metrics.yml"
+        "ocfp/broker.yml"
       )
       ;;
     (override-subdomain)

--- a/ocfp/broker.yml
+++ b/ocfp/broker.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/uris/0
+  value: (( concat "autoscaler-broker." params.cf_system_domain ))


### PR DESCRIPTION
Overwrite upstream URI with our ocfp specific URI path used in the kit and exodus