### PR TITLE
Update cf-app-autoscaler-genesis-kit to pass tests

### DIFF
--- a/overlay/base.yml
+++ b/overlay/base.yml
@@ -26,9 +26,6 @@ bosh-variables:
     ca:             (( grab bosh-variables.loggregator_ca.certificate ))
     certificate:    (( vault meta.cf.exodus ":loggregator_tls_agent_cert" ))
     private_key:    (( vault meta.cf.exodus ":loggregator_tls_agent_key" ))
-  loggregator_tls_rlp:
-    certificate:    (( vault meta.cf.exodus ":loggregator_tls_rlp_cert" ))
-    private_key:    (( vault meta.cf.exodus ":loggregator_tls_rlp_key" ))
 
   skip_ssl_validation: (( grab params.skip_ssl_validation || "true" ))
 

--- a/overlay/cf-v1-support.yml
+++ b/overlay/cf-v1-support.yml
@@ -21,6 +21,3 @@ bosh-variables:
   loggregator_tls_agent:
     certificate: (( param "Please specify the Loggregrator TLS Certificate" ))
     private_key: (( param "Please specify the Loggregrator TLS Private Key" ))
-  loggregator_tls_rlp:
-    certificate: (( param "Please specify the Loggregrator TLS RLP Certificate" ))
-    private_key: (( param "Please specify the Loggregrator TLS RLP Private Key" ))

--- a/spec/credhub/base.yml
+++ b/spec/credhub/base.yml
@@ -1,49 +1,122 @@
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
-autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+loggr_syslog_agent_cache_tls:
+  ca: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+loggr_syslog_agent_metrics:
+  ca: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+loggr_syslog_agent_tls:
+  ca: <!{credhub}:loggr_syslog_agent_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+loggr_syslog_binding_cache_api_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+loggr_syslog_binding_cache_metrics:
+  ca: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+loggr_syslog_binding_cache_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_ca_cert:
+  ca: <!{credhub}:metricscollector_ca_cert.ca!>
+  certificate: <!{credhub}:metricscollector_ca_cert.certificate!>
+  private_key: <!{credhub}:metricscollector_ca_cert.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_autoscaler_metricsforwarder_loggregator_tls:
+  ca: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+  certificate: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+  private_key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>
 database_password: <!{credhub}:database_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
+autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -52,60 +125,3 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
-autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
-autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
-autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
-autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>

--- a/spec/credhub/cf-v1-support.yml
+++ b/spec/credhub/cf-v1-support.yml
@@ -1,49 +1,5 @@
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
 autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
 database_password: <!{credhub}:database_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -52,60 +8,130 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
 autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
 autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
 autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
 autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
 autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>
+autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+loggr_syslog_agent_cache_tls:
+  ca: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+loggr_syslog_agent_metrics:
+  ca: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+loggr_syslog_agent_tls:
+  ca: <!{credhub}:loggr_syslog_agent_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+loggr_syslog_binding_cache_api_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+loggr_syslog_binding_cache_metrics:
+  ca: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+loggr_syslog_binding_cache_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+metricscollector_ca_cert:
+  ca: <!{credhub}:metricscollector_ca_cert.ca!>
+  certificate: <!{credhub}:metricscollector_ca_cert.certificate!>
+  private_key: <!{credhub}:metricscollector_ca_cert.private_key!>
+metricsforwarder_autoscaler_metricsforwarder_loggregator_tls:
+  ca: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+  certificate: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+  private_key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>

--- a/spec/credhub/external-db.yml
+++ b/spec/credhub/external-db.yml
@@ -1,48 +1,4 @@
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
 autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -51,60 +7,120 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
 autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
 autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
 autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
 autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
 autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+loggr_syslog_agent_cache_tls:
+  ca: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+loggr_syslog_agent_metrics:
+  ca: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+loggr_syslog_agent_tls:
+  ca: <!{credhub}:loggr_syslog_agent_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+loggr_syslog_binding_cache_api_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+loggr_syslog_binding_cache_metrics:
+  ca: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+loggr_syslog_binding_cache_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_ca_cert:
+  ca: <!{credhub}:metricscollector_ca_cert.ca!>
+  certificate: <!{credhub}:metricscollector_ca_cert.certificate!>
+  private_key: <!{credhub}:metricscollector_ca_cert.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_autoscaler_metricsforwarder_loggregator_tls:
+  ca: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+  certificate: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+  private_key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>

--- a/spec/credhub/mysql.yml
+++ b/spec/credhub/mysql.yml
@@ -1,49 +1,123 @@
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
+# New variables
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
+autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
+autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
 autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
 database_password: <!{credhub}:database_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+loggr_syslog_agent_cache_tls:
+  ca: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+loggr_syslog_agent_metrics:
+  ca: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+loggr_syslog_agent_tls:
+  ca: <!{credhub}:loggr_syslog_agent_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+loggr_syslog_binding_cache_api_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+loggr_syslog_binding_cache_metrics:
+  ca: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+loggr_syslog_binding_cache_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_ca_cert:
+  ca: <!{credhub}:metricscollector_ca_cert.ca!>
+  certificate: <!{credhub}:metricscollector_ca_cert.certificate!>
+  private_key: <!{credhub}:metricscollector_ca_cert.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_autoscaler_metricsforwarder_loggregator_tls:
+  ca: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+  certificate: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+  private_key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -52,60 +126,3 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
-autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
-autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
-autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
-autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>

--- a/spec/credhub/new-cf.yml
+++ b/spec/credhub/new-cf.yml
@@ -6,69 +6,15 @@
   ca: <!{credhub}:log_cache.ca!>
   certificate: <!{credhub}:log_cache.certificate!>
   private_key: <!{credhub}:log_cache.private_key!>
-/base-test-bosh/base-test-cf/loggregator_ca:
-  ca: <!{credhub}:loggregator_ca.ca!>
-  certificate: <!{credhub}:loggregator_ca.certificate!>
-  private_key: <!{credhub}:loggregator_ca.private_key!>
 /base-test-bosh/base-test-cf/loggregator_tls_agent:
   ca: <!{credhub}:loggregator_tls_agent.ca!>
   certificate: <!{credhub}:loggregator_tls_agent.certificate!>
   private_key: <!{credhub}:loggregator_tls_agent.private_key!>
-/base-test-bosh/base-test-cf/loggregator_tls_rlp:
-  ca: <!{credhub}:loggregator_tls_rlp.ca!>
-  certificate: <!{credhub}:loggregator_tls_rlp.certificate!>
-  private_key: <!{credhub}:loggregator_tls_rlp.private_key!>
 /base-test-bosh/base-test-cf/nats_client_cert:
   ca: <!{credhub}:nats_client_cert.ca!>
   certificate: <!{credhub}:nats_client_cert.certificate!>
   private_key: <!{credhub}:nats_client_cert.private_key!>
-
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
-autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
 database_password: <!{credhub}:database_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -77,60 +23,98 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
 autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
 autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
 autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
 autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
 autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>
+autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>

--- a/spec/credhub/params.yml
+++ b/spec/credhub/params.yml
@@ -1,48 +1,4 @@
-apiserver_ca:
-  ca: <!{credhub}:apiserver_ca.ca!>
-  certificate: <!{credhub}:apiserver_ca.certificate!>
-  private_key: <!{credhub}:apiserver_ca.private_key!>
-apiserver_client:
-  ca: <!{credhub}:apiserver_client.ca!>
-  certificate: <!{credhub}:apiserver_client.certificate!>
-  private_key: <!{credhub}:apiserver_client.private_key!>
-apiserver_public_ca:
-  ca: <!{credhub}:apiserver_public_ca.ca!>
-  certificate: <!{credhub}:apiserver_public_ca.certificate!>
-  private_key: <!{credhub}:apiserver_public_ca.private_key!>
-apiserver_public_server:
-  ca: <!{credhub}:apiserver_public_server.ca!>
-  certificate: <!{credhub}:apiserver_public_server.certificate!>
-  private_key: <!{credhub}:apiserver_public_server.private_key!>
-apiserver_server:
-  ca: <!{credhub}:apiserver_server.ca!>
-  certificate: <!{credhub}:apiserver_server.certificate!>
-  private_key: <!{credhub}:apiserver_server.private_key!>
 autoscaler_service_broker_password: <!{credhub}:autoscaler_service_broker_password!>
-eventgenerator_ca:
-  ca: <!{credhub}:eventgenerator_ca.ca!>
-  certificate: <!{credhub}:eventgenerator_ca.certificate!>
-  private_key: <!{credhub}:eventgenerator_ca.private_key!>
-eventgenerator_client:
-  ca: <!{credhub}:eventgenerator_client.ca!>
-  certificate: <!{credhub}:eventgenerator_client.certificate!>
-  private_key: <!{credhub}:eventgenerator_client.private_key!>
-eventgenerator_server:
-  ca: <!{credhub}:eventgenerator_server.ca!>
-  certificate: <!{credhub}:eventgenerator_server.certificate!>
-  private_key: <!{credhub}:eventgenerator_server.private_key!>
-metricsserver_ca:
-  ca: <!{credhub}:metricsserver_ca.ca!>
-  certificate: <!{credhub}:metricsserver_ca.certificate!>
-  private_key: <!{credhub}:metricsserver_ca.private_key!>
-metricsserver_client:
-  ca: <!{credhub}:metricsserver_client.ca!>
-  certificate: <!{credhub}:metricsserver_client.certificate!>
-  private_key: <!{credhub}:metricsserver_client.private_key!>
-metricsserver_server:
-  ca: <!{credhub}:metricsserver_server.ca!>
-  certificate: <!{credhub}:metricsserver_server.certificate!>
-  private_key: <!{credhub}:metricsserver_server.private_key!>
 postgres_ca:
   ca: <!{credhub}:postgres_ca.ca!>
   certificate: <!{credhub}:postgres_ca.certificate!>
@@ -51,60 +7,120 @@ postgres_server:
   ca: <!{credhub}:postgres_server.ca!>
   certificate: <!{credhub}:postgres_server.certificate!>
   private_key: <!{credhub}:postgres_server.private_key!>
-scalingengine_ca:
-  ca: <!{credhub}:scalingengine_ca.ca!>
-  certificate: <!{credhub}:scalingengine_ca.certificate!>
-  private_key: <!{credhub}:scalingengine_ca.private_key!>
-scalingengine_client:
-  ca: <!{credhub}:scalingengine_client.ca!>
-  certificate: <!{credhub}:scalingengine_client.certificate!>
-  private_key: <!{credhub}:scalingengine_client.private_key!>
-scalingengine_server:
-  ca: <!{credhub}:scalingengine_server.ca!>
-  certificate: <!{credhub}:scalingengine_server.certificate!>
-  private_key: <!{credhub}:scalingengine_server.private_key!>
-scheduler_ca:
-  ca: <!{credhub}:scheduler_ca.ca!>
-  certificate: <!{credhub}:scheduler_ca.certificate!>
-  private_key: <!{credhub}:scheduler_ca.private_key!>
-scheduler_client:
-  ca: <!{credhub}:scheduler_client.ca!>
-  certificate: <!{credhub}:scheduler_client.certificate!>
-  private_key: <!{credhub}:scheduler_client.private_key!>
-scheduler_server:
-  ca: <!{credhub}:scheduler_server.ca!>
-  certificate: <!{credhub}:scheduler_server.certificate!>
-  private_key: <!{credhub}:scheduler_server.private_key!>
-servicebroker_ca:
-  ca: <!{credhub}:servicebroker_ca.ca!>
-  certificate: <!{credhub}:servicebroker_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_ca.private_key!>
-servicebroker_client:
-  ca: <!{credhub}:servicebroker_client.ca!>
-  certificate: <!{credhub}:servicebroker_client.certificate!>
-  private_key: <!{credhub}:servicebroker_client.private_key!>
-servicebroker_public_ca:
-  ca: <!{credhub}:servicebroker_public_ca.ca!>
-  certificate: <!{credhub}:servicebroker_public_ca.certificate!>
-  private_key: <!{credhub}:servicebroker_public_ca.private_key!>
-servicebroker_public_server:
-  ca: <!{credhub}:servicebroker_public_server.ca!>
-  certificate: <!{credhub}:servicebroker_public_server.certificate!>
-  private_key: <!{credhub}:servicebroker_public_server.private_key!>
-servicebroker_server:
-  ca: <!{credhub}:servicebroker_server.ca!>
-  certificate: <!{credhub}:servicebroker_server.certificate!>
-  private_key: <!{credhub}:servicebroker_server.private_key!>
 autoscaler_eventgenerator_health_password: <!{credhub}:autoscaler_eventgenerator_health_password!>
 autoscaler_metricsforwarder_health_password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-autoscaler_metricsgateway_health_password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-autoscaler_metricsserver_health_password: <!{credhub}:autoscaler_metricsserver_health_password!>
 autoscaler_operator_health_password: <!{credhub}:autoscaler_operator_health_password!>
 autoscaler_scalingengine_health_password: <!{credhub}:autoscaler_scalingengine_health_password!>
 autoscaler_scheduler_health_password: <!{credhub}:autoscaler_scheduler_health_password!>
-loggregator_agent_metrics_tls:
-  ca: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-  certificate: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-  private_key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-metric_scraper_ca:
-  ca: <!{credhub}:metric_scraper_ca.ca!>
+api_client_id: <!{credhub}:api_client_id!>
+api_client_secret: <!{credhub}:api_client_secret!>
+apiserver_monitor_basic_auth_password: <!{credhub}:apiserver_monitor_basic_auth_password!>
+apiserver_server_cert:
+  ca: <!{credhub}:apiserver_server_cert.ca!>
+  certificate: <!{credhub}:apiserver_server_cert.certificate!>
+  private_key: <!{credhub}:apiserver_server_cert.private_key!>
+app_autoscaler_ca_cert:
+  ca: <!{credhub}:app_autoscaler_ca_cert.ca!>
+  certificate: <!{credhub}:app_autoscaler_ca_cert.certificate!>
+  private_key: <!{credhub}:app_autoscaler_ca_cert.private_key!>
+app_autoscaler_sbss_restricted_dbuser_password: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password!>
+app_autoscaler_sbss_restricted_dbuser_password_blue: <!{credhub}:app_autoscaler_sbss_restricted_dbuser_password_blue!>
+auditlog_monitor_basic_auth_password: <!{credhub}:auditlog_monitor_basic_auth_password!>
+dashboard_client_id: <!{credhub}:dashboard_client_id!>
+dashboard_client_secret: <!{credhub}:dashboard_client_secret!>
+dashboard_monitor_basic_auth_password: <!{credhub}:dashboard_monitor_basic_auth_password!>
+eventgenerator_client_cert:
+  ca: <!{credhub}:eventgenerator_client_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_client_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+eventgenerator_monitor_basic_auth_password: <!{credhub}:eventgenerator_monitor_basic_auth_password!>
+eventgenerator_server_cert:
+  ca: <!{credhub}:eventgenerator_server_cert.ca!>
+  certificate: <!{credhub}:eventgenerator_server_cert.certificate!>
+  private_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+log_cache_syslog_tls_ca:
+  ca: <!{credhub}:log_cache_syslog_tls_ca.ca!>
+  certificate: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+  private_key: <!{credhub}:log_cache_syslog_tls_ca.private_key!>
+loggr_syslog_agent_cache_tls:
+  ca: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+loggr_syslog_agent_metrics:
+  ca: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+loggr_syslog_agent_tls:
+  ca: <!{credhub}:loggr_syslog_agent_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+loggr_syslog_binding_cache_api_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+loggr_syslog_binding_cache_metrics:
+  ca: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+loggr_syslog_binding_cache_tls:
+  ca: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+  certificate: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+  private_key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+metricscollector_ca:
+  ca: <!{credhub}:metricscollector_ca.ca!>
+  certificate: <!{credhub}:metricscollector_ca.certificate!>
+  private_key: <!{credhub}:metricscollector_ca.private_key!>
+metricscollector_ca_cert:
+  ca: <!{credhub}:metricscollector_ca_cert.ca!>
+  certificate: <!{credhub}:metricscollector_ca_cert.certificate!>
+  private_key: <!{credhub}:metricscollector_ca_cert.private_key!>
+metricscollector_client:
+  ca: <!{credhub}:metricscollector_client.ca!>
+  certificate: <!{credhub}:metricscollector_client.certificate!>
+  private_key: <!{credhub}:metricscollector_client.private_key!>
+metricscollector_server:
+  ca: <!{credhub}:metricscollector_server.ca!>
+  certificate: <!{credhub}:metricscollector_server.certificate!>
+  private_key: <!{credhub}:metricscollector_server.private_key!>
+metricsforwarder_autoscaler_metricsforwarder_loggregator_tls:
+  ca: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+  certificate: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+  private_key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+metricsforwarder_monitor_basic_auth_password: <!{credhub}:metricsforwarder_monitor_basic_auth_password!>
+operator_monitor_basic_auth_password: <!{credhub}:operator_monitor_basic_auth_password!>
+postgres_client:
+  ca: <!{credhub}:postgres_client.ca!>
+  certificate: <!{credhub}:postgres_client.certificate!>
+  private_key: <!{credhub}:postgres_client.private_key!>
+scalingengine_client_cert:
+  ca: <!{credhub}:scalingengine_client_cert.ca!>
+  certificate: <!{credhub}:scalingengine_client_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_client_cert.private_key!>
+scalingengine_monitor_basic_auth_password: <!{credhub}:scalingengine_monitor_basic_auth_password!>
+scalingengine_server_cert:
+  ca: <!{credhub}:scalingengine_server_cert.ca!>
+  certificate: <!{credhub}:scalingengine_server_cert.certificate!>
+  private_key: <!{credhub}:scalingengine_server_cert.private_key!>
+scheduler_client_cert:
+  ca: <!{credhub}:scheduler_client_cert.ca!>
+  certificate: <!{credhub}:scheduler_client_cert.certificate!>
+  private_key: <!{credhub}:scheduler_client_cert.private_key!>
+scheduler_monitor_basic_auth_password: <!{credhub}:scheduler_monitor_basic_auth_password!>
+scheduler_server_cert:
+  ca: <!{credhub}:scheduler_server_cert.ca!>
+  certificate: <!{credhub}:scheduler_server_cert.certificate!>
+  private_key: <!{credhub}:scheduler_server_cert.private_key!>
+service_broker_password: <!{credhub}:service_broker_password!>
+service_broker_password_blue: <!{credhub}:service_broker_password_blue!>
+servicebroker_server_cert:
+  ca: <!{credhub}:servicebroker_server_cert.ca!>
+  certificate: <!{credhub}:servicebroker_server_cert.certificate!>
+  private_key: <!{credhub}:servicebroker_server_cert.private_key!>
+syslog_agent_log_cache_tls:
+  ca: <!{credhub}:syslog_agent_log_cache_tls.ca!>
+  certificate: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+  private_key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+uaa_client_id: <!{credhub}:uaa_client_id!>
+uaa_secret: <!{credhub}:uaa_secret!>
+metriccollector_monitor_basic_auth_password: <!{credhub}:metriccollector_monitor_basic_auth_password!>
+ratelimiter_monitor_basic_auth_password: <!{credhub}:ratelimiter_monitor_basic_auth_password!>

--- a/spec/deployments/cf-v1-support.yml
+++ b/spec/deployments/cf-v1-support.yml
@@ -19,6 +19,3 @@ bosh-variables:
   loggregator_tls_agent:
     certificate: test-loggregator-agent-cert
     private_key: test-loggregator-agent-key
-  loggregator_tls_rlp:
-    certificate: test-loggregator-rlp-cert
-    private_key: test-loggregator-rlp-key

--- a/spec/deployments/params.yml
+++ b/spec/deployments/params.yml
@@ -35,6 +35,4 @@ bosh-variables:
   loggregator_tls_agent:
     certificate: test-loggregator-agent-cert
     private_key: test-loggregator-agent-key
-  loggregator_tls_rlp:
-    certificate: test-loggregator-rlp-cert
-    private_key: test-loggregator-rlp-key
+

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: test-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: base-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: base-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: test-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: base-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: base-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: test-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: base-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: test-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cf
-          domain: bosh
-          instance_group: log-api
-          network: test-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: base-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: test-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: base-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: test-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: test-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-api
+          network: test-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cf
@@ -80,15 +66,48 @@ addons:
           instance_group: nats
           network: test-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: base-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: base-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
     release: bosh-dns-aliases
   name: bosh-dns-aliases
 - jobs:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: base-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: base-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: base-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: base-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: base-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: base-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: base
@@ -110,6 +129,7 @@ instance_groups:
   - name: postgres
     properties:
       databases:
+        address: autoscalerpostgres.service.cf.internal
         connection_config:
           connection_max_lifetime: 60s
           max_idle_connections: 10
@@ -151,6 +171,7 @@ instance_groups:
           secret: app-autoscaler-secret
           skip_ssl_validation: "true"
         policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -174,21 +195,17 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -212,6 +229,7 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -235,214 +253,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.sys.test.cf.domain
-          client_id: app-autoscaler-client
-          grant_type: client_credentials
-          secret: app-autoscaler-secret
-          skip_ssl_validation: "true"
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats:
         deployment: base-test-cf
@@ -457,315 +267,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.sys.test.cf.domain
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.sys.test.cf.domain
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.sys.test.cf.domain
+          - app-autoscaler-scalingengine.sys.test.cf.domain
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:metricsserver_ca.ca!>
-            client_cert: <!{credhub}:metricsserver_client.certificate!>
-            client_key: <!{credhub}:metricsserver_client.private_key!>
-            host: metricsserver.service.cf.internal
-            port: 6103
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.sys.test.cf.domain
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.sys.test.cf.domain
-    release: routing
-  name: asmetrics
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-rlp-cert
-              key: test-loggregator-rlp-key
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.sys.test.cf.domain
-    release: routing
-  name: asnozzle
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -775,45 +283,54 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.sys.test.cf.domain
+            mtls_host: app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -832,10 +349,6 @@ instance_groups:
             ca: <!{credhub}:postgres_ca.ca!>
             certificate: <!{credhub}:postgres_server.certificate!>
             private_key: <!{credhub}:postgres_server.private_key!>
-        binding_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
         cf:
           api: https://api.sys.test.cf.domain
           client_id: app-autoscaler-client
@@ -843,51 +356,7 @@ instance_groups:
           secret: app-autoscaler-secret
           skip_ssl_validation: "true"
         policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: metricsforwarder
-    properties:
-      autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
-          health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
-          logging:
-            level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-agent-cert
-              key: test-loggregator-agent-key
-          policy_poller_interval: 60s
-          server:
-            port: 6201
-        policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -933,6 +402,487 @@ instance_groups:
             component: autoscaler_service_broker
           uris:
           - autoscalerservicebroker.sys.test.cf.domain
+    release: routing
+  name: apiserver
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
+    properties:
+      autoscaler:
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
+          health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.sys.test.cf.domain
+    release: routing
+  name: scheduler
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.sys.test.cf.domain
+          client_id: app-autoscaler-client
+          grant_type: client_credentials
+          secret: app-autoscaler-secret
+          skip_ssl_validation: "true"
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
+          logging:
+            level: info
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.sys.test.cf.domain
+    release: routing
+  name: operator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:metricscollector_ca_cert.ca!>
+            client_cert: <!{credhub}:metricscollector_client.certificate!>
+            client_key: <!{credhub}:metricscollector_client.private_key!>
+            host: logcache
+            port: 8080
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - app-autoscaler-eventgenerator.sys.test.cf.domain
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+              cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+              key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_agent_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cf
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+        cert: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+        key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -940,66 +890,56 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metrics_forwarder_mtls
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metrics_forwarder
+          uris:
+          - app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
         - name: autoscaler_metricsforwarder_health
-          port: 6403
+          port: 6201
           registration_interval: 20s
           tags:
             component: autoscaler_metricsforwarder_health
           uris:
-          - autoscaler-metricsforwarder.sys.test.cf.domain
+          - app-autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - consumes:
-      doppler:
-        deployment: base-test-cf
-        from: doppler
-    name: loggregator_agent
-    properties:
-      loggregator:
-        tls:
-          agent:
-            cert: test-loggregator-agent-cert
-            key: test-loggregator-agent-key
-          ca_cert: test-loggregator-ca
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: base-cf-app-autoscaler
+public_domains:
+  metricsforwarder: base-cf-app-autoscalermetrics.sys.test.cf.domain
+  metricsforwarder_mtls: base-cf-app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+  servicebroker: base-cf-app-autoscalerservicebroker.sys.test.cf.domain
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: postgres
-  sha1: 582b1de9522077102dfa44ff7164cd8f499dbfc8
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=44
-  version: "44"
+  sha1: sha256:75ceb40c970c54a922768d499bee9102d7a2ae2f88e269cefecba2f1c195e70b
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=48
+  version: "48"
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: routing
-  sha1: 0024f2d9f8bb3c624a162db4c3a5919388c6d800
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.237.0
-  version: 0.237.0
+  sha1: sha256:18df3f00881de9b82b6c3e9a6e96871a2330ed5c0ea595431cabe64782ba5035
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.285.0
+  version: 0.285.0
 - name: loggregator-agent
-  sha1: 02ec285cce8fef717ab7baee79a5ed9210a7391c
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.4.1
-  version: 6.4.1
+  sha1: sha256:4b7d5dd3eb2c4ed5d0a9f7957d5044c3da294a083ffdf395b5ddee2ff2360780
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.7.3
+  version: 7.7.3
 - name: bpm
-  sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
-  version: 1.1.18
+  sha1: sha256:14a2b83254ba5a833baf7fc2d297edfa2ad01452e9b9281785e1eb6b906e5d9c
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.13
+  version: 1.2.13
 stemcells:
 - alias: default
   os: ubuntu-jammy
@@ -1007,6 +947,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/spec/results/cf-v1-support.yml
+++ b/spec/results/cf-v1-support.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: test-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: cf-v1-support-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: cf-v1-support-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: test-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: cf-v1-support-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: cf-v1-support-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: test-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: cf-v1-support-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: test-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cf
-          domain: bosh
-          instance_group: loggregator_trafficcontroller
-          network: test-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: cf-v1-support-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: test-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: cf-v1-support-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: test-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: test-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: loggregator_trafficcontroller
+          network: test-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cf
@@ -80,15 +66,48 @@ addons:
           instance_group: nats
           network: test-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: cf-v1-support-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: cf-v1-support-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
     release: bosh-dns-aliases
   name: bosh-dns-aliases
 - jobs:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: cf-v1-support-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: cf-v1-support-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: cf-v1-support-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: cf-v1-support-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: cf-v1-support-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: cf-v1-support-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: cf-v1-support
@@ -110,6 +129,7 @@ instance_groups:
   - name: postgres
     properties:
       databases:
+        address: autoscalerpostgres.service.cf.internal
         connection_config:
           connection_max_lifetime: 60s
           max_idle_connections: 10
@@ -151,6 +171,7 @@ instance_groups:
           secret: some-client-secret
           skip_ssl_validation: "true"
         policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -174,21 +195,17 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -212,6 +229,7 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -235,214 +253,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.sys.test.cf.domain
-          client_id: some-client-id
-          grant_type: client_credentials
-          secret: some-client-secret
-          skip_ssl_validation: "true"
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats:
         deployment: base-test-cf
@@ -457,315 +267,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.sys.test.cf.domain
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.sys.test.cf.domain
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.sys.test.cf.domain
+          - app-autoscaler-scalingengine.sys.test.cf.domain
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:metricsserver_ca.ca!>
-            client_cert: <!{credhub}:metricsserver_client.certificate!>
-            client_key: <!{credhub}:metricsserver_client.private_key!>
-            host: metricsserver.service.cf.internal
-            port: 6103
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.sys.test.cf.domain
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.sys.test.cf.domain
-    release: routing
-  name: asmetrics
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-rlp-cert
-              key: test-loggregator-rlp-key
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.sys.test.cf.domain
-    release: routing
-  name: asnozzle
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -775,45 +283,54 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.sys.test.cf.domain
+            mtls_host: app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -832,10 +349,6 @@ instance_groups:
             ca: <!{credhub}:postgres_ca.ca!>
             certificate: <!{credhub}:postgres_server.certificate!>
             private_key: <!{credhub}:postgres_server.private_key!>
-        binding_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
         cf:
           api: https://api.sys.test.cf.domain
           client_id: some-client-id
@@ -843,51 +356,7 @@ instance_groups:
           secret: some-client-secret
           skip_ssl_validation: "true"
         policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: metricsforwarder
-    properties:
-      autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
-          health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
-          logging:
-            level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-agent-cert
-              key: test-loggregator-agent-key
-          policy_poller_interval: 60s
-          server:
-            port: 6201
-        policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -933,6 +402,487 @@ instance_groups:
             component: autoscaler_service_broker
           uris:
           - autoscalerservicebroker.sys.test.cf.domain
+    release: routing
+  name: apiserver
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
+    properties:
+      autoscaler:
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
+          health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.sys.test.cf.domain
+    release: routing
+  name: scheduler
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.sys.test.cf.domain
+          client_id: some-client-id
+          grant_type: client_credentials
+          secret: some-client-secret
+          skip_ssl_validation: "true"
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
+          logging:
+            level: info
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.sys.test.cf.domain
+    release: routing
+  name: operator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:metricscollector_ca_cert.ca!>
+            client_cert: <!{credhub}:metricscollector_client.certificate!>
+            client_key: <!{credhub}:metricscollector_client.private_key!>
+            host: logcache
+            port: 8080
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - app-autoscaler-eventgenerator.sys.test.cf.domain
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+              cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+              key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_agent_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cf
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+        cert: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+        key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -940,66 +890,56 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metrics_forwarder_mtls
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metrics_forwarder
+          uris:
+          - app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
         - name: autoscaler_metricsforwarder_health
-          port: 6403
+          port: 6201
           registration_interval: 20s
           tags:
             component: autoscaler_metricsforwarder_health
           uris:
-          - autoscaler-metricsforwarder.sys.test.cf.domain
+          - app-autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - consumes:
-      doppler:
-        deployment: base-test-cf
-        from: doppler
-    name: loggregator_agent
-    properties:
-      loggregator:
-        tls:
-          agent:
-            cert: test-loggregator-agent-cert
-            key: test-loggregator-agent-key
-          ca_cert: test-loggregator-ca
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: cf-v1-support-cf-app-autoscaler
+public_domains:
+  metricsforwarder: cf-v1-support-cf-app-autoscalermetrics.sys.test.cf.domain
+  metricsforwarder_mtls: cf-v1-support-cf-app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+  servicebroker: cf-v1-support-cf-app-autoscalerservicebroker.sys.test.cf.domain
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: postgres
-  sha1: 582b1de9522077102dfa44ff7164cd8f499dbfc8
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=44
-  version: "44"
+  sha1: sha256:75ceb40c970c54a922768d499bee9102d7a2ae2f88e269cefecba2f1c195e70b
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=48
+  version: "48"
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: routing
-  sha1: 0024f2d9f8bb3c624a162db4c3a5919388c6d800
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.237.0
-  version: 0.237.0
+  sha1: sha256:18df3f00881de9b82b6c3e9a6e96871a2330ed5c0ea595431cabe64782ba5035
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.285.0
+  version: 0.285.0
 - name: loggregator-agent
-  sha1: 02ec285cce8fef717ab7baee79a5ed9210a7391c
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.4.1
-  version: 6.4.1
+  sha1: sha256:4b7d5dd3eb2c4ed5d0a9f7957d5044c3da294a083ffdf395b5ddee2ff2360780
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.7.3
+  version: 7.7.3
 - name: bpm
-  sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
-  version: 1.1.18
+  sha1: sha256:14a2b83254ba5a833baf7fc2d297edfa2ad01452e9b9281785e1eb6b906e5d9c
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.13
+  version: 1.2.13
 stemcells:
 - alias: default
   os: ubuntu-bionic
@@ -1007,6 +947,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/spec/results/external-db.yml
+++ b/spec/results/external-db.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: test-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: external-db-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: external-db-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: test-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: external-db-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: external-db-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: test-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: external-db-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: test-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cf
-          domain: bosh
-          instance_group: log-api
-          network: test-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: external-db-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: test-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: external-db-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: test-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: test-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-api
+          network: test-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cf
@@ -80,15 +66,48 @@ addons:
           instance_group: nats
           network: test-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: external-db-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: external-db-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
     release: bosh-dns-aliases
   name: bosh-dns-aliases
 - jobs:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: external-db-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: external-db-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: external-db-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: external-db-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: external-db-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: external-db-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: external-db
@@ -135,20 +154,15 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
           address: external.mysql.mycorp.com
           databases:
@@ -186,179 +200,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.sys.test.cf.domain
-          client_id: app-autoscaler-client
-          grant_type: client_credentials
-          secret: app-autoscaler-secret
-          skip_ssl_validation: "true"
-        instancemetrics_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats:
         deployment: base-test-cf
@@ -373,290 +214,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.sys.test.cf.domain
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.sys.test.cf.domain
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.sys.test.cf.domain
+          - app-autoscaler-scalingengine.sys.test.cf.domain
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:metricsserver_ca.ca!>
-            client_cert: <!{credhub}:metricsserver_client.certificate!>
-            client_key: <!{credhub}:metricsserver_client.private_key!>
-            host: metricsserver.service.cf.internal
-            port: 6103
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.sys.test.cf.domain
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.sys.test.cf.domain
-    release: routing
-  name: asmetrics
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-rlp-cert
-              key: test-loggregator-rlp-key
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          address: external.mysql.mycorp.com
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: autoscaler
-            password: ((autoscaler_database_password))
-            tag: default
-          sslmode: verify-ca
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.sys.test.cf.domain
-    release: routing
-  name: asnozzle
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -666,42 +230,50 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.sys.test.cf.domain
+            mtls_host: app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
@@ -747,27 +319,301 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: metricsforwarder
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: api_server
+          port: 6101
+          registration_interval: 20s
+          tags:
+            component: api_server
+          uris:
+          - autoscaler.sys.test.cf.domain
+        - name: autoscaler_service_broker
+          port: 6102
+          registration_interval: 20s
+          tags:
+            component: autoscaler_service_broker
+          uris:
+          - autoscalerservicebroker.sys.test.cf.domain
+    release: routing
+  name: apiserver
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
     properties:
       autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
+        policy_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
           health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.sys.test.cf.domain
+    release: routing
+  name: scheduler
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.sys.test.cf.domain
+          client_id: app-autoscaler-client
+          grant_type: client_credentials
+          secret: app-autoscaler-secret
+          skip_ssl_validation: "true"
+        lock_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        lock_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
           logging:
             level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-agent-cert
-              key: test-loggregator-agent-key
-          policy_poller_interval: 60s
-          server:
-            port: 6201
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.sys.test.cf.domain
+    release: routing
+  name: operator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:metricscollector_ca_cert.ca!>
+            client_cert: <!{credhub}:metricscollector_client.certificate!>
+            client_key: <!{credhub}:metricscollector_client.private_key!>
+            host: logcache
+            port: 8080
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        lock_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
         policy_db:
           address: external.mysql.mycorp.com
           databases:
@@ -795,20 +641,133 @@ instance_groups:
     properties:
       route_registrar:
         routes:
-        - name: api_server
-          port: 6101
+        - name: autoscaler_eventgenerator_health
+          port: 6205
           registration_interval: 20s
           tags:
-            component: api_server
+            component: autoscaler_eventgenerator_health
           uris:
-          - autoscaler.sys.test.cf.domain
-        - name: autoscaler_service_broker
-          port: 6102
-          registration_interval: 20s
-          tags:
-            component: autoscaler_service_broker
-          uris:
-          - autoscalerservicebroker.sys.test.cf.domain
+          - app-autoscaler-eventgenerator.sys.test.cf.domain
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+              cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+              key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: external.mysql.mycorp.com
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: autoscaler
+            password: ((autoscaler_database_password))
+            tag: default
+          sslmode: verify-ca
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        storedprocedure_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_agent_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cf
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+        cert: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+        key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -816,62 +775,52 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metrics_forwarder_mtls
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metrics_forwarder
+          uris:
+          - app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
         - name: autoscaler_metricsforwarder_health
-          port: 6403
+          port: 6201
           registration_interval: 20s
           tags:
             component: autoscaler_metricsforwarder_health
           uris:
-          - autoscaler-metricsforwarder.sys.test.cf.domain
+          - app-autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - consumes:
-      doppler:
-        deployment: base-test-cf
-        from: doppler
-    name: loggregator_agent
-    properties:
-      loggregator:
-        tls:
-          agent:
-            cert: test-loggregator-agent-cert
-            key: test-loggregator-agent-key
-          ca_cert: test-loggregator-ca
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: external-db-cf-app-autoscaler
+public_domains:
+  metricsforwarder: external-db-cf-app-autoscalermetrics.sys.test.cf.domain
+  metricsforwarder_mtls: external-db-cf-app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+  servicebroker: external-db-cf-app-autoscalerservicebroker.sys.test.cf.domain
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: routing
-  sha1: 0024f2d9f8bb3c624a162db4c3a5919388c6d800
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.237.0
-  version: 0.237.0
+  sha1: sha256:18df3f00881de9b82b6c3e9a6e96871a2330ed5c0ea595431cabe64782ba5035
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.285.0
+  version: 0.285.0
 - name: loggregator-agent
-  sha1: 02ec285cce8fef717ab7baee79a5ed9210a7391c
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.4.1
-  version: 6.4.1
+  sha1: sha256:4b7d5dd3eb2c4ed5d0a9f7957d5044c3da294a083ffdf395b5ddee2ff2360780
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.7.3
+  version: 7.7.3
 - name: bpm
-  sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
-  version: 1.1.18
+  sha1: sha256:14a2b83254ba5a833baf7fc2d297edfa2ad01452e9b9281785e1eb6b906e5d9c
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.13
+  version: 1.2.13
 stemcells:
 - alias: default
   os: ubuntu-jammy
@@ -879,6 +828,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/spec/results/mysql.yml
+++ b/spec/results/mysql.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: test-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: mysql-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: mysql-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: test-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: mysql-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: mysql-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: test-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: mysql-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: test-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cf
-          domain: bosh
-          instance_group: log-api
-          network: test-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: mysql-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: test-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: mysql-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: test-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: test-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-api
+          network: test-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cf
@@ -80,6 +66,32 @@ addons:
           instance_group: nats
           network: test-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: mysql-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: mysql-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
       - domain: sql-db.service.cf.internal
         targets:
         - deployment: cf
@@ -93,9 +105,16 @@ addons:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: mysql-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: mysql-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: mysql-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: mysql-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: mysql-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: mysql-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: mysql
@@ -142,20 +161,15 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
           address: sql-db.service.cf.internal
           databases:
@@ -193,179 +207,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.sys.test.cf.domain
-          client_id: app-autoscaler-client
-          grant_type: client_credentials
-          secret: app-autoscaler-secret
-          skip_ssl_validation: "true"
-        instancemetrics_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats:
         deployment: base-test-cf
@@ -380,290 +221,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.sys.test.cf.domain
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.sys.test.cf.domain
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.sys.test.cf.domain
+          - app-autoscaler-scalingengine.sys.test.cf.domain
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:metricsserver_ca.ca!>
-            client_cert: <!{credhub}:metricsserver_client.certificate!>
-            client_key: <!{credhub}:metricsserver_client.private_key!>
-            host: metricsserver.service.cf.internal
-            port: 6103
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.sys.test.cf.domain
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.sys.test.cf.domain
-    release: routing
-  name: asmetrics
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-rlp-cert
-              key: test-loggregator-rlp-key
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          address: sql-db.service.cf.internal
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: mysql
-          port: 3306
-          roles:
-          - name: autoscaler
-            password: <!somepassword!>
-            tag: default
-          sslmode: "false"
-          tls:
-            ca: <!mysql_server_certificate.ca!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cf
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.sys.test.cf.domain
-    release: routing
-  name: asnozzle
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -673,42 +237,50 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.sys.test.cf.domain
+            mtls_host: app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
@@ -754,27 +326,303 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: metricsforwarder
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: api_server
+          port: 6101
+          registration_interval: 20s
+          tags:
+            component: api_server
+          uris:
+          - autoscaler.sys.test.cf.domain
+        - name: autoscaler_service_broker
+          port: 6102
+          registration_interval: 20s
+          tags:
+            component: autoscaler_service_broker
+          uris:
+          - autoscalerservicebroker.sys.test.cf.domain
+    release: routing
+  name: apiserver
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
     properties:
       autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
+        policy_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
           health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.sys.test.cf.domain
+    release: routing
+  name: scheduler
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.sys.test.cf.domain
+          client_id: app-autoscaler-client
+          grant_type: client_credentials
+          secret: app-autoscaler-secret
+          skip_ssl_validation: "true"
+        lock_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        lock_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
           logging:
             level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-agent-cert
-              key: test-loggregator-agent-key
-          policy_poller_interval: 60s
-          server:
-            port: 6201
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.sys.test.cf.domain
+    release: routing
+  name: operator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:metricscollector_ca_cert.ca!>
+            client_cert: <!{credhub}:metricscollector_client.certificate!>
+            client_key: <!{credhub}:metricscollector_client.private_key!>
+            host: logcache
+            port: 8080
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
         policy_db:
           address: sql-db.service.cf.internal
           databases:
@@ -802,20 +650,135 @@ instance_groups:
     properties:
       route_registrar:
         routes:
-        - name: api_server
-          port: 6101
+        - name: autoscaler_eventgenerator_health
+          port: 6205
           registration_interval: 20s
           tags:
-            component: api_server
+            component: autoscaler_eventgenerator_health
           uris:
-          - autoscaler.sys.test.cf.domain
-        - name: autoscaler_service_broker
-          port: 6102
-          registration_interval: 20s
-          tags:
-            component: autoscaler_service_broker
-          uris:
-          - autoscalerservicebroker.sys.test.cf.domain
+          - app-autoscaler-eventgenerator.sys.test.cf.domain
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+              cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+              key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: sql-db.service.cf.internal
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: autoscaler
+            password: <!somepassword!>
+            tag: default
+          sslmode: "false"
+          tls:
+            ca: <!mysql_server_certificate.ca!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_agent_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cf
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+        cert: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+        key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats:
+        deployment: base-test-cf
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -823,62 +786,52 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
+        - name: autoscaler_metrics_forwarder_mtls
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metrics_forwarder
+          uris:
+          - app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
         - name: autoscaler_metricsforwarder_health
-          port: 6403
+          port: 6201
           registration_interval: 20s
           tags:
             component: autoscaler_metricsforwarder_health
           uris:
-          - autoscaler-metricsforwarder.sys.test.cf.domain
+          - app-autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - consumes:
-      doppler:
-        deployment: base-test-cf
-        from: doppler
-    name: loggregator_agent
-    properties:
-      loggregator:
-        tls:
-          agent:
-            cert: test-loggregator-agent-cert
-            key: test-loggregator-agent-key
-          ca_cert: test-loggregator-ca
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: mysql-cf-app-autoscaler
+public_domains:
+  metricsforwarder: mysql-cf-app-autoscalermetrics.sys.test.cf.domain
+  metricsforwarder_mtls: mysql-cf-app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+  servicebroker: mysql-cf-app-autoscalerservicebroker.sys.test.cf.domain
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: routing
-  sha1: 0024f2d9f8bb3c624a162db4c3a5919388c6d800
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.237.0
-  version: 0.237.0
+  sha1: sha256:18df3f00881de9b82b6c3e9a6e96871a2330ed5c0ea595431cabe64782ba5035
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.285.0
+  version: 0.285.0
 - name: loggregator-agent
-  sha1: 02ec285cce8fef717ab7baee79a5ed9210a7391c
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.4.1
-  version: 6.4.1
+  sha1: sha256:4b7d5dd3eb2c4ed5d0a9f7957d5044c3da294a083ffdf395b5ddee2ff2360780
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.7.3
+  version: 7.7.3
 - name: bpm
-  sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
-  version: 1.1.18
+  sha1: sha256:14a2b83254ba5a833baf7fc2d297edfa2ad01452e9b9281785e1eb6b906e5d9c
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.13
+  version: 1.2.13
 stemcells:
 - alias: default
   os: ubuntu-jammy
@@ -886,6 +839,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/spec/results/new-cf.yml
+++ b/spec/results/new-cf.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: test-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: new-cf-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: new-cf-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: test-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: new-cf-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: test-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: new-cf-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: test-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: new-cf-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: test-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cf
-          domain: bosh
-          instance_group: log-api
-          network: test-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: new-cf-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: test-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: new-cf-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: test-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: test-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-api
+          network: test-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cf
@@ -80,6 +66,32 @@ addons:
           instance_group: nats
           network: test-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cf
+          domain: bosh
+          instance_group: log-cache
+          network: test-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: new-cf-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: new-cf-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: test-core-network
+          query: '*'
       - domain: log-cache
         targets:
         - deployment: base-test-cf
@@ -93,9 +105,16 @@ addons:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: new-cf-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: new-cf-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: new-cf-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: new-cf-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: new-cf-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: new-cf-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.sys.test.cf.domain
   autoscaler_metrics_domain: autoscalermetrics.sys.test.cf.domain
   bosh: new-cf
@@ -117,6 +136,7 @@ instance_groups:
   - name: postgres
     properties:
       databases:
+        address: autoscalerpostgres.service.cf.internal
         connection_config:
           connection_max_lifetime: 60s
           max_idle_connections: 10
@@ -158,6 +178,7 @@ instance_groups:
           secret: app-autoscaler-secret
           skip_ssl_validation: "true"
         policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -181,21 +202,17 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -219,6 +236,7 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -242,214 +260,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.sys.test.cf.domain
-          client_id: app-autoscaler-client
-          grant_type: client_credentials
-          secret: app-autoscaler-secret
-          skip_ssl_validation: "true"
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats-tls:
         deployment: base-test-cf
@@ -469,326 +279,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.sys.test.cf.domain
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.sys.test.cf.domain
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.sys.test.cf.domain
+          - app-autoscaler-scalingengine.sys.test.cf.domain
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:log_cache.ca!>
-            client_cert: <!{credhub}:log_cache.certificate!>
-            client_key: <!{credhub}:log_cache.private_key!>
-            host: log-cache
-            port: 8080
-            use_log_cache: true
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats-tls:
-        deployment: base-test-cf
-        from: nats-tls
-    name: route_registrar
-    properties:
-      nats:
-        tls:
-          client_cert: <!{credhub}:nats_client_cert.certificate!>
-          client_key: <!{credhub}:nats_client_cert.private_key!>
-          enabled: true
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.sys.test.cf.domain
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.sys.test.cf.domain
-    release: routing
-  name: asmetrics
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: <!{credhub}:loggregator_ca.certificate!>
-              cert: <!{credhub}:loggregator_tls_rlp.certificate!>
-              key: <!{credhub}:loggregator_tls_rlp.private_key!>
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats-tls:
-        deployment: base-test-cf
-        from: nats-tls
-    name: route_registrar
-    properties:
-      nats:
-        tls:
-          client_cert: <!{credhub}:nats_client_cert.certificate!>
-          client_key: <!{credhub}:nats_client_cert.private_key!>
-          enabled: true
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.sys.test.cf.domain
-    release: routing
-  name: asnozzle
-  networks:
-  - name: test-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -798,46 +295,54 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.sys.test.cf.domain
-            mtls_host: autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+            mtls_host: app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -856,10 +361,6 @@ instance_groups:
             ca: <!{credhub}:postgres_ca.ca!>
             certificate: <!{credhub}:postgres_server.certificate!>
             private_key: <!{credhub}:postgres_server.private_key!>
-        binding_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
         cf:
           api: https://api.sys.test.cf.domain
           client_id: app-autoscaler-client
@@ -867,54 +368,7 @@ instance_groups:
           secret: app-autoscaler-secret
           skip_ssl_validation: "true"
         policy_db:
-          connection_config:
-            connection_max_lifetime: 60s
-            max_idle_connections: 10
-            max_open_connections: 100
-          databases:
-          - name: autoscaler
-            tag: default
-          db_scheme: postgres
-          port: 5432
-          roles:
-          - name: postgres
-            password: <!{credhub}:database_password!>
-            tag: default
-          sslmode: verify-full
-          tls:
-            ca: <!{credhub}:postgres_ca.ca!>
-            certificate: <!{credhub}:postgres_server.certificate!>
-            private_key: <!{credhub}:postgres_server.private_key!>
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: metricsforwarder
-    properties:
-      autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
-          health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
-          logging:
-            level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
-              cert: <!{credhub}:loggregator_tls_agent.certificate!>
-              key: <!{credhub}:loggregator_tls_agent.private_key!>
-          metricshandler:
-            tls:
-              ca_cert: <!{credhub}:diego_instance_identity_ca.certificate!>
-          policy_poller_interval: 60s
-          server:
-            port: 6201
-        policy_db:
+          address: autoscalerpostgres.service.cf.internal
           connection_config:
             connection_max_lifetime: 60s
             max_idle_connections: 10
@@ -965,6 +419,508 @@ instance_groups:
             component: autoscaler_service_broker
           uris:
           - autoscalerservicebroker.sys.test.cf.domain
+    release: routing
+  name: apiserver
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
+    properties:
+      autoscaler:
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
+          health:
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - consumes:
+      nats-tls:
+        deployment: base-test-cf
+        from: nats-tls
+    name: route_registrar
+    properties:
+      nats:
+        tls:
+          client_cert: <!{credhub}:nats_client_cert.certificate!>
+          client_key: <!{credhub}:nats_client_cert.private_key!>
+          enabled: true
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.sys.test.cf.domain
+    release: routing
+  name: scheduler
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.sys.test.cf.domain
+          client_id: app-autoscaler-client
+          grant_type: client_credentials
+          secret: app-autoscaler-secret
+          skip_ssl_validation: "true"
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
+          logging:
+            level: info
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats-tls:
+        deployment: base-test-cf
+        from: nats-tls
+    name: route_registrar
+    properties:
+      nats:
+        tls:
+          client_cert: <!{credhub}:nats_client_cert.certificate!>
+          client_key: <!{credhub}:nats_client_cert.private_key!>
+          enabled: true
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.sys.test.cf.domain
+    release: routing
+  name: operator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:log_cache.ca!>
+            client_cert: <!{credhub}:log_cache.certificate!>
+            client_key: <!{credhub}:log_cache.private_key!>
+            host: log-cache
+            port: 8080
+            use_log_cache: true
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+    release: app-autoscaler
+  - consumes:
+      nats-tls:
+        deployment: base-test-cf
+        from: nats-tls
+    name: route_registrar
+    properties:
+      nats:
+        tls:
+          client_cert: <!{credhub}:nats_client_cert.certificate!>
+          client_key: <!{credhub}:nats_client_cert.private_key!>
+          enabled: true
+      route_registrar:
+        routes:
+        - name: autoscaler_eventgenerator_health
+          port: 6205
+          registration_interval: 20s
+          tags:
+            component: autoscaler_eventgenerator_health
+          uris:
+          - app-autoscaler-eventgenerator.sys.test.cf.domain
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: test-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+              cert: <!{credhub}:loggregator_tls_agent.certificate!>
+              key: <!{credhub}:loggregator_tls_agent.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: autoscalerpostgres.service.cf.internal
+          connection_config:
+            connection_max_lifetime: 60s
+            max_idle_connections: 10
+            max_open_connections: 100
+          databases:
+          - name: autoscaler
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: postgres
+            password: <!{credhub}:database_password!>
+            tag: default
+          sslmode: verify-full
+          tls:
+            ca: <!{credhub}:postgres_ca.ca!>
+            certificate: <!{credhub}:postgres_server.certificate!>
+            private_key: <!{credhub}:postgres_server.private_key!>
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+          cert: <!{credhub}:loggregator_tls_agent.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggregator_tls_agent.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+        cert: <!{credhub}:loggregator_tls_agent.certificate!>
+        key: <!{credhub}:loggregator_tls_agent.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+        cert: <!{credhub}:loggregator_tls_agent.certificate!>
+        key: <!{credhub}:loggregator_tls_agent.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cf
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:loggregator_tls_agent.ca!>
+        cert: <!{credhub}:loggregator_tls_agent.certificate!>
+        key: <!{credhub}:loggregator_tls_agent.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+          cert: <!{credhub}:loggregator_tls_agent.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggregator_tls_agent.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+        cert: <!{credhub}:loggregator_tls_agent.certificate!>
+        key: <!{credhub}:loggregator_tls_agent.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
+        cert: <!{credhub}:loggregator_tls_agent.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggregator_tls_agent.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats-tls:
+        deployment: base-test-cf
+        from: nats-tls
+    name: route_registrar
+    properties:
+      nats:
+        tls:
+          client_cert: <!{credhub}:nats_client_cert.certificate!>
+          client_key: <!{credhub}:nats_client_cert.private_key!>
+          enabled: true
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -972,53 +928,59 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.sys.test.cf.domain
-        - name: autoscaler_metricsforwarder_health
-          port: 6403
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsforwarder_health
-          uris:
-          - autoscaler-metricsforwarder.sys.test.cf.domain
         - name: autoscaler_metrics_forwarder_mtls
           port: 6201
           registration_interval: 20s
           tags:
-            component: autoscaler_metrics_forwarder_mtls
+            component: autoscaler_metrics_forwarder
           uris:
-          - autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+          - app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+        - name: autoscaler_metricsforwarder_health
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metricsforwarder_health
+          uris:
+          - app-autoscaler-metricsforwarder.sys.test.cf.domain
     release: routing
-  - name: loggr-syslog-agent
-    properties:
-      aggregate_drains: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
-      drain_ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-      tls:
-        ca_cert: <!{credhub}:loggregator_tls_agent.ca!>
-        cert: <!{credhub}:loggregator_tls_agent.certificate!>
-        key: <!{credhub}:loggregator_tls_agent.private_key!>
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: test-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: new-cf-cf-app-autoscaler
+operations:
+- path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/metricshandler?
+  type: replace
+  value:
+    tls:
+      ca_cert: <!{credhub}:diego_instance_identity_ca.certificate!>
+- path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/metrics_forwarder/mtls_host?
+  type: replace
+  value: autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+- path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/-
+  type: replace
+  value:
+    name: autoscaler_metrics_forwarder_mtls
+    port: 6201
+    registration_interval: 20s
+    tags:
+      component: autoscaler_metrics_forwarder_mtls
+    uris:
+    - autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+public_domains:
+  metricsforwarder: new-cf-cf-app-autoscalermetrics.sys.test.cf.domain
+  metricsforwarder_mtls: new-cf-cf-app-autoscaler-metricsforwarder-mtls.sys.test.cf.domain
+  servicebroker: new-cf-cf-app-autoscalerservicebroker.sys.test.cf.domain
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: postgres
-  sha1: 582b1de9522077102dfa44ff7164cd8f499dbfc8
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=44
-  version: "44"
+  sha1: sha256:75ceb40c970c54a922768d499bee9102d7a2ae2f88e269cefecba2f1c195e70b
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=48
+  version: "48"
 - name: bosh-dns-aliases
   sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
@@ -1042,6 +1004,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/spec/results/params.yml
+++ b/spec/results/params.yml
@@ -10,60 +10,39 @@ addons:
           instance_group: postgres_autoscaler
           network: cf-v1-core-network
           query: '*'
-      - domain: apiserver.service.cf.internal
+      - domain: autoscaler.service.cf.internal
         targets:
         - deployment: params-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: cf-v1-core-network
           query: '*'
       - domain: autoscalerscheduler.service.cf.internal
         targets:
         - deployment: params-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
+          instance_group: scheduler
           network: cf-v1-core-network
           query: '*'
       - domain: servicebroker.service.cf.internal
         targets:
         - deployment: params-cf-app-autoscaler
           domain: bosh
-          instance_group: asapi
+          instance_group: apiserver
           network: cf-v1-core-network
           query: '*'
       - domain: eventgenerator.service.cf.internal
         targets:
         - deployment: params-cf-app-autoscaler
           domain: bosh
-          instance_group: asmetrics
+          instance_group: eventgenerator
           network: cf-v1-core-network
           query: '*'
       - domain: scalingengine.service.cf.internal
         targets:
         - deployment: params-cf-app-autoscaler
           domain: bosh
-          instance_group: asactors
-          network: cf-v1-core-network
-          query: '*'
-      - domain: reverse-log-proxy.service.cf.internal
-        targets:
-        - deployment: base-test-cfv1
-          domain: bosh
-          instance_group: loggregator_trafficcontroller
-          network: cf-v1-core-network
-          query: '*'
-      - domain: metricsgateway.service.cf.internal
-        targets:
-        - deployment: params-cf-app-autoscaler
-          domain: bosh
-          instance_group: asnozzle
-          network: cf-v1-core-network
-          query: '*'
-      - domain: metricsserver.service.cf.internal
-        targets:
-        - deployment: params-cf-app-autoscaler
-          domain: bosh
-          instance_group: asmetrics
+          instance_group: scalingengine
           network: cf-v1-core-network
           query: '*'
       - domain: nats.service.cf.internal
@@ -73,6 +52,13 @@ addons:
           instance_group: nats
           network: cf-v1-core-network
           query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: base-test-cfv1
+          domain: bosh
+          instance_group: loggregator_trafficcontroller
+          network: cf-v1-core-network
+          query: '*'
       - domain: _.nats.service.cf.internal
         targets:
         - deployment: base-test-cfv1
@@ -80,15 +66,48 @@ addons:
           instance_group: nats
           network: cf-v1-core-network
           query: _
+      - domain: logcache
+        targets:
+        - deployment: base-test-cfv1
+          domain: bosh
+          instance_group: log-cache
+          network: cf-v1-core-network
+          query: '*'
+      - domain: log-cache.service.cf.internal
+        targets:
+        - deployment: base-test-cfv1
+          domain: bosh
+          instance_group: log-cache
+          network: cf-v1-core-network
+          query: '*'
+      - domain: metricsgateway.service.cf.internal
+        targets:
+        - deployment: params-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: cf-v1-core-network
+          query: '*'
+      - domain: metricsserver.service.cf.internal
+        targets:
+        - deployment: params-cf-app-autoscaler
+          instance_group: metricsforwarder
+          network: cf-v1-core-network
+          query: '*'
     release: bosh-dns-aliases
   name: bosh-dns-aliases
 - jobs:
   - name: bpm
     release: bpm
   name: bpm
+domains:
+  api: params-cf-app-autoscaler.apiserver.service.cf.internal
+  eventgenerator: params-cf-app-autoscaler.eventgenerator.service.cf.internal
+  postgres: params-cf-app-autoscaler.autoscalerpostgres.service.cf.internal
+  scalingengine: params-cf-app-autoscaler.scalingengine.service.cf.internal
+  scheduler: params-cf-app-autoscaler.autoscalerscheduler.service.cf.internal
+  servicebroker: params-cf-app-autoscaler.servicebroker.service.cf.internal
 exodus:
-  app-autoscaler-release-date: 2023-Jun-28 13:16:36 UTC
-  app-autoscaler-release-version: 10.0.5
+  app-autoscaler-release-date: 2024-Jul-17 12:05:53 UTC
+  app-autoscaler-release-version: 14.1.0
   autoscaler_api_domain: autoscaler.cf-v1.lab.example.com
   autoscaler_metrics_domain: autoscalermetrics.cf-v1.lab.example.com
   bosh: params
@@ -135,20 +154,15 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
         scalingengine:
-          ca_cert: <!{credhub}:scalingengine_ca.ca!>
-          defaultCoolDownSecs: 300
+          ca_cert: <!{credhub}:app_autoscaler_ca_cert.ca!>
           health:
             password: <!{credhub}:autoscaler_scalingengine_health_password!>
             port: 6204
             username: scalingengine
-          http_client_timeout: 60s
-          lockSize: 32
           logging:
             level: info
-          server:
-            port: 6104
-          server_cert: <!{credhub}:scalingengine_server.certificate!>
-          server_key: <!{credhub}:scalingengine_server.private_key!>
+          server_cert: <!{credhub}:scalingengine_server_cert.certificate!>
+          server_key: <!{credhub}:scalingengine_server_cert.private_key!>
         scalingengine_db:
           address: external-mysql-host.lab.example.com
           databases:
@@ -186,179 +200,6 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: scheduler
-    properties:
-      autoscaler:
-        policy_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        scheduler:
-          ca_cert: <!{credhub}:scheduler_ca.ca!>
-          health:
-            basicAuthEnabled: true
-            password: <!{credhub}:autoscaler_scheduler_health_password!>
-            port: 6202
-            username: scheduler
-          http_client_timeout: 60
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          port: 6102
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-          server_cert: <!{credhub}:scheduler_server.certificate!>
-          server_key: <!{credhub}:scheduler_server.private_key!>
-        scheduler_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-    release: app-autoscaler
-  - name: operator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        cf:
-          api: https://api.cf-v1.lab.example.com
-          client_id: some-client-id
-          grant_type: client_credentials
-          secret: some-client-secret
-          skip_ssl_validation: true
-        instancemetrics_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        lock_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        lock_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        operator:
-          app_sync_interval: 24h
-          db_lock:
-            retry_interval: 5s
-            ttl: 15s
-          health:
-            password: <!{credhub}:autoscaler_operator_health_password!>
-            port: 6208
-            username: operator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            port: 6104
-          scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
-            host: autoscalerscheduler.service.cf.internal
-            port: 6102
-        policy_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        scalingengine_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        scalingengine_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
   - consumes:
       nats:
         deployment: base-test-cfv1
@@ -373,290 +214,13 @@ instance_groups:
           tags:
             component: autoscaler_scalingengine_health
           uris:
-          - autoscaler-scalingengine.cf-v1.lab.example.com
-        - name: autoscaler_operator_health
-          port: 6208
-          registration_interval: 20s
-          tags:
-            component: autoscaler_operator_health
-          uris:
-          - autoscaler-operator.cf-v1.lab.example.com
-        - name: autoscaler_scheduler_health
-          port: 6202
-          registration_interval: 20s
-          tags:
-            component: autoscaler_scheduler_health
-          uris:
-          - autoscaler-scheduler.cf-v1.lab.example.com
+          - app-autoscaler-scalingengine.cf-v1.lab.example.com
     release: routing
-  name: asactors
+  name: scalingengine
   networks:
   - name: cf-v1-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsserver
-    properties:
-      autoscaler:
-        instancemetrics_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        instancemetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        metricsserver:
-          ca_cert: <!{credhub}:metricsserver_server.ca!>
-          collector:
-            collect_interval: 60s
-            envelope_channel_size: 1000
-            envelope_processor_count: 5
-            keep_alive_time: 60s
-            metric_cache_size_per_app: 1000
-            metric_channel_size: 1000
-            persist_metrics: true
-            port: 7103
-            refresh_interval: 60s
-            save_interval: 5s
-          health:
-            password: <!{credhub}:autoscaler_metricsserver_health_password!>
-            port: 6303
-            username: metricsserver
-          http_client_timeout: 60s
-          logging:
-            level: info
-          server:
-            port: 6103
-          server_cert: <!{credhub}:metricsserver_server.certificate!>
-          server_key: <!{credhub}:metricsserver_server.private_key!>
-        policy_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - name: eventgenerator
-    properties:
-      autoscaler:
-        appmetrics_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        appmetrics_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-        eventgenerator:
-          aggregator:
-            aggregator_execute_interval: 40s
-            app_metric_channel_size: 1000
-            app_monitor_channel_size: 200
-            metric_poller_count: 20
-            policy_poller_interval: 60s
-            save_interval: 5s
-          ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-          circuitBreaker:
-            back_off_initial_interval: 5m
-            back_off_max_interval: 120m
-            consecutive_failure_count: 5
-          defaultBreachDurationSecs: 120
-          defaultStatWindowSecs: 120
-          evaluator:
-            evaluation_manager_execute_interval: 60s
-            evaluator_count: 20
-            trigger_array_channel_size: 200
-          health:
-            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
-            port: 6205
-            username: eventgenerator
-          http_client_timeout: 60s
-          logging:
-            level: info
-          metricscollector:
-            ca_cert: <!{credhub}:metricsserver_ca.ca!>
-            client_cert: <!{credhub}:metricsserver_client.certificate!>
-            client_key: <!{credhub}:metricsserver_client.private_key!>
-            host: metricsserver.service.cf.internal
-            port: 6103
-          scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
-            host: scalingengine.service.cf.internal
-            port: 6104
-          server:
-            port: 6105
-          server_cert: <!{credhub}:eventgenerator_server.certificate!>
-          server_key: <!{credhub}:eventgenerator_server.private_key!>
-        policy_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cfv1
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_eventgenerator_health
-          port: 6205
-          registration_interval: 20s
-          tags:
-            component: autoscaler_eventgenerator_health
-          uris:
-          - autoscaler-eventgenerator.cf-v1.lab.example.com
-        - name: autoscaler_metricsserver_health
-          port: 6303
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsserver_health
-          uris:
-          - autoscaler-metricsserver.cf-v1.lab.example.com
-    release: routing
-  name: asmetrics
-  networks:
-  - name: cf-v1-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
-- azs:
-  - z1
-  instances: 1
-  jobs:
-  - name: metricsgateway
-    properties:
-      autoscaler:
-        metricsgateway:
-          app_manager:
-            app_refresh_interval: 5s
-          emitter:
-            buffer_size: 500
-            handshake_timeout: 1s
-            keep_alive_interval: 5s
-            max_close_retry_count: 3
-            max_setup_retry_count: 3
-            metricsserver_client:
-              ca_cert: <!{credhub}:metricsserver_client.ca!>
-              cert: <!{credhub}:metricsserver_client.certificate!>
-              key: <!{credhub}:metricsserver_client.private_key!>
-            retry_delay: 1s
-          envelop_chan_size: 1000
-          health:
-            password: <!{credhub}:autoscaler_metricsgateway_health_password!>
-            port: 6503
-            username: metricsgateway
-          logging:
-            level: info
-          nozzle:
-            loggregator_rlp_tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-rlp-cert
-              key: test-loggregator-rlp-key
-            rlp_addr: reverse-log-proxy.service.cf.internal:8082
-            shard_id: CF_AUTOSCALER
-          nozzle_count: 3
-        policy_db:
-          address: external-mysql-host.lab.example.com
-          databases:
-          - name: cfas
-            tag: default
-          db_scheme: mysql
-          port: 3377
-          roles:
-          - name: as
-            password: $up3r$ecr!t
-            tag: default
-          sslmode: allow
-          tls:
-            ca: ((autoscaler_database_tls_ca))
-        policy_db_connection_config:
-          connection_max_lifetime: 60s
-          max_idle_connections: 10
-          max_open_connections: 100
-    release: app-autoscaler
-  - consumes:
-      nats:
-        deployment: base-test-cfv1
-        from: nats
-    name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: autoscaler_metricsgateway_health
-          port: 6503
-          registration_interval: 20s
-          tags:
-            component: autoscaler_metricsgateway_health
-          uris:
-          - autoscaler-metricsgateway.cf-v1.lab.example.com
-    release: routing
-  name: asnozzle
-  networks:
-  - name: cf-v1-core-network
-  stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
-  vm_type: small
 - azs:
   - z1
   instances: 1
@@ -666,42 +230,50 @@ instance_groups:
       autoscaler:
         apiserver:
           broker:
-            password: <!{credhub}:autoscaler_service_broker_password!>
+            broker_credentials:
+            - broker_password: <!{credhub}:service_broker_password!>
+              broker_username: autoscaler-broker-user
+            - broker_password: <!{credhub}:service_broker_password_blue!>
+              broker_username: autoscaler-broker-user-blue
             server:
               catalog:
                 services:
                 - bindable: true
+                  bindings_retrievable: true
                   description: Automatically increase or decrease the number of application
                     instances based on a policy you define.
                   id: autoscaler-guid
-                  name: autoscaler
+                  instances_retrievable: true
+                  name: app-autoscaler
                   plans:
                   - description: This is the free service plan for the Auto-Scaling
                       service.
                     id: autoscaler-free-plan-id
                     name: autoscaler-free-plan
+                  tags:
+                  - app-autoscaler
               dashboard_redirect_uri: ""
               port: 6102
-            username: autoscaler_service_broker_user
           event_generator:
-            ca_cert: <!{credhub}:eventgenerator_ca.ca!>
-            client_cert: <!{credhub}:eventgenerator_client.certificate!>
-            client_key: <!{credhub}:eventgenerator_client.private_key!>
-          logging:
-            level: info
+            ca_cert: <!{credhub}:eventgenerator_client_cert.ca!>
+            client_cert: <!{credhub}:eventgenerator_client_cert.certificate!>
+            client_key: <!{credhub}:eventgenerator_client_cert.private_key!>
+            host: eventgenerator.service.cf.internal
           metrics_forwarder:
             host: autoscalermetrics.cf-v1.lab.example.com
+            mtls_host: app-autoscaler-metricsforwarder-mtls.cf-v1.lab.example.com
           public_api:
             server:
               port: 6101
           scaling_engine:
-            ca_cert: <!{credhub}:scalingengine_ca.ca!>
-            client_cert: <!{credhub}:scalingengine_client.certificate!>
-            client_key: <!{credhub}:scalingengine_client.private_key!>
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
           scheduler:
-            ca_cert: <!{credhub}:scheduler_ca.ca!>
-            client_cert: <!{credhub}:scheduler_client.certificate!>
-            client_key: <!{credhub}:scheduler_client.private_key!>
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
             host: autoscalerscheduler.service.cf.internal
           use_buildin_mode: false
         binding_db:
@@ -747,27 +319,301 @@ instance_groups:
           max_idle_connections: 10
           max_open_connections: 100
     release: app-autoscaler
-  - name: metricsforwarder
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: api_server
+          port: 6101
+          registration_interval: 20s
+          tags:
+            component: api_server
+          uris:
+          - autoscaler.cf-v1.lab.example.com
+        - name: autoscaler_service_broker
+          port: 6102
+          registration_interval: 20s
+          tags:
+            component: autoscaler_service_broker
+          uris:
+          - autoscalerservicebroker.cf-v1.lab.example.com
+    release: routing
+  name: apiserver
+  networks:
+  - name: cf-v1-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: scheduler
     properties:
       autoscaler:
-        metricsforwarder:
-          cache_cleanup_interval: 6h
-          cache_ttl: 900s
+        policy_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        scheduler:
+          ca_cert: <!{credhub}:scheduler_server_cert.ca!>
           health:
-            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
-            port: 6403
-            username: metricsforwarder
+            basicAuthEnabled: true
+            password: <!{credhub}:autoscaler_scheduler_health_password!>
+            port: 6202
+            username: scheduler
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:scheduler_server_cert.certificate!>
+          server_key: <!{credhub}:scheduler_server_cert.private_key!>
+        scheduler_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_scheduler_health
+          port: 6202
+          registration_interval: 20s
+          tags:
+            component: autoscaler_scheduler_health
+          uris:
+          - app-autoscaler-scheduler.cf-v1.lab.example.com
+    release: routing
+  name: scheduler
+  networks:
+  - name: cf-v1-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: operator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        cf:
+          api: https://api.cf-v1.lab.example.com
+          client_id: some-client-id
+          grant_type: client_credentials
+          secret: some-client-secret
+          skip_ssl_validation: true
+        lock_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        lock_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        operator:
+          enable_db_lock: true
+          health:
+            password: <!{credhub}:autoscaler_operator_health_password!>
+            port: 6208
+            username: operator
           logging:
             level: info
-          loggregator:
-            metron_address: 127.0.0.1:3458
-            tls:
-              ca_cert: test-loggregator-ca
-              cert: test-loggregator-agent-cert
-              key: test-loggregator-agent-key
-          policy_poller_interval: 60s
-          server:
-            port: 6201
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          scheduler:
+            ca_cert: <!{credhub}:scheduler_client_cert.ca!>
+            client_cert: <!{credhub}:scheduler_client_cert.certificate!>
+            client_key: <!{credhub}:scheduler_client_cert.private_key!>
+            host: autoscalerscheduler.service.cf.internal
+        policy_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scalingengine_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        scalingengine_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        scheduler.host: autoscalerscheduler.service.cf.internal
+    release: app-autoscaler
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: autoscaler_operator_health
+          port: 6208
+          registration_interval: 20s
+          tags:
+            component: autoscaler_operator_health
+          uris:
+          - app-autoscaler-operator.cf-v1.lab.example.com
+    release: routing
+  name: operator
+  networks:
+  - name: cf-v1-core-network
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: eventgenerator
+    properties:
+      autoscaler:
+        appmetrics_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        appmetrics_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        eventgenerator:
+          ca_cert: <!{credhub}:eventgenerator_server_cert.ca!>
+          enable_db_lock: false
+          health:
+            password: <!{credhub}:autoscaler_eventgenerator_health_password!>
+            port: 6205
+            username: eventgenerator
+          logging:
+            level: info
+          metricscollector:
+            ca_cert: <!{credhub}:metricscollector_ca_cert.ca!>
+            client_cert: <!{credhub}:metricscollector_client.certificate!>
+            client_key: <!{credhub}:metricscollector_client.private_key!>
+            host: logcache
+            port: 8080
+          scaling_engine:
+            ca_cert: <!{credhub}:scalingengine_client_cert.ca!>
+            client_cert: <!{credhub}:scalingengine_client_cert.certificate!>
+            client_key: <!{credhub}:scalingengine_client_cert.private_key!>
+            host: scalingengine.service.cf.internal
+          server_cert: <!{credhub}:eventgenerator_server_cert.certificate!>
+          server_key: <!{credhub}:eventgenerator_server_cert.private_key!>
+        lock_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        lock_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
         policy_db:
           address: external-mysql-host.lab.example.com
           databases:
@@ -795,20 +641,133 @@ instance_groups:
     properties:
       route_registrar:
         routes:
-        - name: api_server
-          port: 6101
+        - name: autoscaler_eventgenerator_health
+          port: 6205
           registration_interval: 20s
           tags:
-            component: api_server
+            component: autoscaler_eventgenerator_health
           uris:
-          - autoscaler.cf-v1.lab.example.com
-        - name: autoscaler_service_broker
-          port: 6102
-          registration_interval: 20s
-          tags:
-            component: autoscaler_service_broker
-          uris:
-          - autoscalerservicebroker.cf-v1.lab.example.com
+          - app-autoscaler-eventgenerator.cf-v1.lab.example.com
+    release: routing
+  name: eventgenerator
+  networks:
+  - name: cf-v1-core-network
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: metricsforwarder
+    properties:
+      autoscaler:
+        metricsforwarder:
+          health:
+            password: <!{credhub}:autoscaler_metricsforwarder_health_password!>
+            port: 6403
+            username: metricsforwarder
+          logging:
+            level: info
+          loggregator:
+            tls:
+              ca_cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.ca!>
+              cert: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.certificate!>
+              key: <!{credhub}:metricsforwarder_autoscaler_metricsforwarder_loggregator_tls.private_key!>
+          server:
+            port: 6201
+        policy_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        policy_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+        storedprocedure_db:
+          address: external-mysql-host.lab.example.com
+          databases:
+          - name: cfas
+            tag: default
+          db_scheme: mysql
+          port: 3377
+          roles:
+          - name: as
+            password: $up3r$ecr!t
+            tag: default
+          sslmode: allow
+          tls:
+            ca: ((autoscaler_database_tls_ca))
+        storedprocedure_db_connection_config:
+          connection_max_lifetime: 60s
+          max_idle_connections: 10
+          max_open_connections: 100
+    release: app-autoscaler
+  - name: loggr-syslog-agent
+    properties:
+      cache:
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_agent_cache_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_agent_cache_tls.certificate!>
+          cn: loggr_syslog_binding_cache
+          key: <!{credhub}:loggr_syslog_agent_cache_tls.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_agent_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_agent_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_agent_tls.certificate!>
+        key: <!{credhub}:loggr_syslog_agent_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      cloud_controller:
+        deployment: base-test-cfv1
+        from: cloud_controller
+    name: loggr-syslog-binding-cache
+    properties:
+      aggregate_drains:
+      - ca: <!{credhub}:log_cache_syslog_tls_ca.certificate!>
+        cert: <!{credhub}:syslog_agent_log_cache_tls.certificate!>
+        key: <!{credhub}:syslog_agent_log_cache_tls.private_key!>
+        url: syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true
+      api:
+        polling_interval: 876000h
+        tls:
+          ca_cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.ca!>
+          cert: <!{credhub}:loggr_syslog_binding_cache_api_tls.certificate!>
+          cn: api.tls.config.is.required.by.job.specification.but.not.needed.in.our.case
+          key: <!{credhub}:loggr_syslog_binding_cache_api_tls.private_key!>
+      external_port: 9000
+      metrics:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_metrics.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_metrics.certificate!>
+        key: <!{credhub}:loggr_syslog_binding_cache_metrics.private_key!>
+        server_name: metrics.config.is.required.by.job.specification.but.not.needed.in.our.case
+      tls:
+        ca_cert: <!{credhub}:loggr_syslog_binding_cache_tls.ca!>
+        cert: <!{credhub}:loggr_syslog_binding_cache_tls.certificate!>
+        cn: loggr_syslog_agent_tls
+        key: <!{credhub}:loggr_syslog_binding_cache_tls.private_key!>
+    release: loggregator-agent
+  - consumes:
+      nats:
+        deployment: base-test-cfv1
+        from: nats
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
         - name: autoscaler_metrics_forwarder
           port: 6201
           registration_interval: 20s
@@ -816,62 +775,52 @@ instance_groups:
             component: autoscaler_metrics_forwarder
           uris:
           - autoscalermetrics.cf-v1.lab.example.com
+        - name: autoscaler_metrics_forwarder_mtls
+          port: 6201
+          registration_interval: 20s
+          tags:
+            component: autoscaler_metrics_forwarder
+          uris:
+          - app-autoscaler-metricsforwarder-mtls.cf-v1.lab.example.com
         - name: autoscaler_metricsforwarder_health
-          port: 6403
+          port: 6201
           registration_interval: 20s
           tags:
             component: autoscaler_metricsforwarder_health
           uris:
-          - autoscaler-metricsforwarder.cf-v1.lab.example.com
+          - app-autoscaler-metricsforwarder.cf-v1.lab.example.com
     release: routing
-  - consumes:
-      doppler:
-        deployment: base-test-cfv1
-        from: doppler
-    name: loggregator_agent
-    properties:
-      loggregator:
-        tls:
-          agent:
-            cert: test-loggregator-agent-cert
-            key: test-loggregator-agent-key
-          ca_cert: test-loggregator-ca
-      metrics:
-        ca_cert: <!{credhub}:loggregator_agent_metrics_tls.ca!>
-        cert: <!{credhub}:loggregator_agent_metrics_tls.certificate!>
-        key: <!{credhub}:loggregator_agent_metrics_tls.private_key!>
-        server_name: loggregator_agent_server
-    release: loggregator-agent
-  name: asapi
+  name: metricsforwarder
   networks:
   - name: cf-v1-core-network
   stemcell: default
-  update:
-    max_in_flight: 1
-    serial: true
   vm_type: minimal
 name: params-cf-app-autoscaler
+public_domains:
+  metricsforwarder: params-cf-app-autoscalermetrics.cf-v1.lab.example.com
+  metricsforwarder_mtls: params-cf-app-autoscaler-metricsforwarder-mtls.cf-v1.lab.example.com
+  servicebroker: params-cf-app-autoscalerservicebroker.cf-v1.lab.example.com
 releases:
 - name: app-autoscaler
-  sha1: da4e71fceb23b747e1dd71346d1296575fe71669
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=10.0.5
-  version: 10.0.5
+  sha1: 26865030c459bc048739c60d3d3a1874e6bbad85
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=14.1.0
+  version: 14.1.0
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: routing
-  sha1: 0024f2d9f8bb3c624a162db4c3a5919388c6d800
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.237.0
-  version: 0.237.0
+  sha1: sha256:18df3f00881de9b82b6c3e9a6e96871a2330ed5c0ea595431cabe64782ba5035
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.285.0
+  version: 0.285.0
 - name: loggregator-agent
-  sha1: 02ec285cce8fef717ab7baee79a5ed9210a7391c
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.4.1
-  version: 6.4.1
+  sha1: sha256:4b7d5dd3eb2c4ed5d0a9f7957d5044c3da294a083ffdf395b5ddee2ff2360780
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.7.3
+  version: 7.7.3
 - name: bpm
-  sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
-  version: 1.1.18
+  sha1: sha256:14a2b83254ba5a833baf7fc2d297edfa2ad01452e9b9281785e1eb6b906e5d9c
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.13
+  version: 1.2.13
 stemcells:
 - alias: default
   os: ubuntu-xenial
@@ -879,6 +828,7 @@ stemcells:
 update:
   canaries: 1
   canary_watch_time: 1000-300000
-  max_in_flight: 1
+  max_in_flight: 3
+  serial: true
   update_watch_time: 1000-300000
 variables: []

--- a/upstream/operations/cf-mysql-db.yml
+++ b/upstream/operations/cf-mysql-db.yml
@@ -13,9 +13,9 @@
       network: default
       query: '*'
 
-# asactors/scalingengine
+# scalingengine/scalingengine
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scalingengine_db
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine_db
   value: &external_database
     sslmode: &sslmode "false"
     tls: &database_tls
@@ -32,98 +32,98 @@
       tag: default
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scalingengine_db_connection_config
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine_db_connection_config
   value: &databaseConnectionConfig
     max_open_connections: 100
     max_idle_connections: 10
     connection_max_lifetime: 60s
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scheduler_db
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scheduler_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scheduler_db_connection_config
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scheduler_db_connection_config
   value: *databaseConnectionConfig
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/policy_db
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/policy_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/policy_db_connection_config
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
 
-# asactors/scheduler
+# scheduler/scheduler
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scheduler/properties/autoscaler/policy_db
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/autoscaler/policy_db
   value: *external_database
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=scheduler/properties/autoscaler/scheduler_db
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/autoscaler/scheduler_db
   value: *external_database
 
-#asactors/operator
+#operator/operator
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/policy_db
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/policy_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/policy_db_connection_config
-  value: *databaseConnectionConfig
-
-- type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/appmetrics_db
-  value: *external_database
-- type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/appmetrics_db_connection_config
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/scalingengine_db
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/appmetrics_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/scalingengine_db_connection_config
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/appmetrics_db_connection_config
   value: *databaseConnectionConfig
 
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/lock_db
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/scalingengine_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/lock_db_connection_config
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/scalingengine_db_connection_config
+  value: *databaseConnectionConfig
+
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/lock_db
+  value: *external_database
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/lock_db_connection_config?
   value: *databaseConnectionConfig
 
 # asmetrics/eventgenerator
 - type: replace
-  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/appmetrics_db
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/appmetrics_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/appmetrics_db_connection_config
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/appmetrics_db_connection_config
   value: *databaseConnectionConfig
 
 - type: replace
-  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/policy_db
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/policy_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/policy_db_connection_config
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
 
 # asapi/golangapiserver
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/policy_db
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/policy_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/policy_db_connection_config
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/binding_db
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/binding_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/binding_db_connection_config
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/binding_db_connection_config?
   value: *databaseConnectionConfig
 # asapi/metricsforwarder
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/policy_db
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/policy_db
   value: *external_database
 - type: replace
-  path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/policy_db_connection_config
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
 
 

--- a/upstream/operations/external-db.yml
+++ b/upstream/operations/external-db.yml
@@ -1,6 +1,6 @@
 
 - type: remove
-  path: /instance_groups/name=postgres
+  path: /instance_groups/name=postgres_autoscaler
 
 # scalingengine/scalingengine
 - type: replace


### PR DESCRIPTION
This commit updates the test files to align with changes in the latest
 cf-app-autoscaler release:

- Restructured instance groups: renamed asapi to apiserver, asactors to individual components (scalingengine, scheduler, operator), and asmetrics to eventgenerator
- Updated database configurations and connection properties
- Added new properties for metrics forwarding and logging
- Removed deprecated properties like instancemetrics_db and metricsserver
- Updated TLS configurations and certificate references
- Added support for new features like syslog binding cache and loggr-syslog-agent

These changes ensure the test suite accurately reflects the current
 structure and functionality of the cf-app-autoscaler deployment.