### PR TITLE
Update job names in ocfp hooks/check script

### DIFF
--- a/hooks/check
+++ b/hooks/check
@@ -16,7 +16,7 @@ cc_ok=yes
 if [[ -n "$GENESIS_CLOUD_CONFIG" ]] ; then
   if want_feature ocfp ; then
     _env_scale="$(lookup --partial meta.ocfp.env.scale)"
-    jobs=( as-actors as-api as-metrics as-nozzle )
+    jobs=( as-apiserver as-scalingengine as-scheduler as-operator as-eventgenerator as-metricsforwarder )
     for job in ${jobs[@]} ; do
       _vm_type="${job}-${_env_scale}"
       _disk_type="${job}-${_env_scale}"


### PR DESCRIPTION
- Updated the list of job names in the `hooks/check` script to reflect the correct job names (used as instance names)for the cf-app-autoscaler:
  - Changed `as-actors`, `as-api`, `as-metrics`, `as-nozzle`
  - To `as-apiserver`, `as-scalingengine`, `as-scheduler`, `as-operator` , `as-eventgenerator`, `as-metricsforwarder`